### PR TITLE
Fixes Mac build autoupdates

### DIFF
--- a/app/builder.config.js
+++ b/app/builder.config.js
@@ -30,12 +30,16 @@ const ICONS_DIR = 'build/icons/'
 
 const macOS = {
   mac: {
-    // identity: isRelease ? getEnv('CSC_LINK') : null, // Only codesign releases
     // Builds for Intel (x64) + M1 (arm64) chips
     // https://github.com/electron-userland/electron-builder/issues/5689#issuecomment-792876001
     target: {
+      // target: 'default' is required
+      // It creates dmg + zip files for Mac builds
+      // This is expected for auto-updates to work properly
+      // Waiting on: https://github.com/electron-userland/electron-builder/issues/2199
       target: 'default',
-      arch: ['arm64', 'x64'], // Build for M1 chips (arm64) + Intel chips
+      // Build for M1 chips (arm64) + Intel (x64) chips
+      arch: ['arm64', 'x64'],
     },
     icon: ICONS_DIR + 'icon.icns',
     entitlements: 'build/entitlements.mac.plist', // Required for MacOS Catalina

--- a/app/builder.config.js
+++ b/app/builder.config.js
@@ -31,8 +31,10 @@ const ICONS_DIR = 'build/icons/'
 const macOS = {
   mac: {
     // identity: isRelease ? getEnv('CSC_LINK') : null, // Only codesign releases
+    // Builds for Intel (x64) + M1 (arm64) chips
+    // https://github.com/electron-userland/electron-builder/issues/5689#issuecomment-792876001
     target: {
-      target: 'dmg',
+      target: 'default',
       arch: ['arm64', 'x64'], // Build for M1 chips (arm64) + Intel chips
     },
     icon: ICONS_DIR + 'icon.icns',


### PR DESCRIPTION
Error to fix:
1. Intel chip Mac installs v1
2. Opens app
3. App tries to install v2
4. "Downloading update... app-v2-arm64.dmg, app-v2-mac.dmg" <-- 2 packages!
5. Error: ZIP file not provided: [ { url: "...v2-mac.dmg" } ]

Cause:

- `mac: { target: { target: 'dmg' } }` caused ZIP file to not be built for Mac --> but when autoupdating runs (`electron-updater`), it throws an error because no ZIP file is published for releases

Change:

- Changed `mac: { target: { target: 'default' } }`, so that it will build DMG + ZIP

Expected result:
No more error about ZIP file not provided.