### PR TITLE
Add automated app screenshot

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,8 @@
     "postinstall": "electron-builder install-app-deps",
     "storybook": "start-storybook",
     "debug:playwright": "npx cross-env DEBUG=pw:browser* yarn run dev",
-    "debug:build:mac": "./build/mac/Reflex.app/Contents/MacOS/Reflex --args --remote-debugging-port=8315 & open -a \"Google Chrome\" http://localhost:8315"
+    "debug:build:mac": "./build/mac/Reflex.app/Contents/MacOS/Reflex --args --remote-debugging-port=8315 & open -a \"Google Chrome\" http://localhost:8315",
+    "screenshot": "yarn run dev & npx wait-on tcp:9080 && node ./scripts/app-screenshots.js"
   },
   "engines": {
     "node": ">=12.13.0"
@@ -102,6 +103,7 @@
     "native-ext-loader": "2.3.0",
     "node-sass": "5.0.0",
     "nuxt": "^2.15.7",
+    "playwright": "^1.14.1",
     "prettier": "^2.3.2",
     "sass-loader": "10.2.0",
     "shelljs": "^0.8.4",

--- a/app/scripts/app-screenshots.js
+++ b/app/scripts/app-screenshots.js
@@ -1,0 +1,27 @@
+const { _electron: electron } = require('playwright')
+
+;(async () => {
+  // Launch Electron app.
+  const electronApp = await electron.launch({
+    args: ['./dist/main/index.js'],
+  })
+
+  // Evaluation expression in the Electron context.
+  const appPath = await electronApp.evaluate(async ({ app }) => {
+    // This runs in the main Electron process, parameter here is always
+    // the result of the require('electron') in the main app script.
+    return app.getAppPath()
+  })
+
+  // Get the first window that the app opens, wait if necessary
+  const window = await electronApp.firstWindow()
+
+  // Direct Electron console to Node terminal
+  window.on('console', console.log)
+
+  // Capture a screenshot
+  await window.screenshot({ path: 'screenshot.png' })
+
+  // Exit app
+  await electronApp.close()
+})()

--- a/app/scripts/app-screenshots.js
+++ b/app/scripts/app-screenshots.js
@@ -1,27 +1,47 @@
 const { _electron: electron } = require('playwright')
+const fs = require('fs')
+const path = require('path')
 
 ;(async () => {
-  // Launch Electron app.
-  const electronApp = await electron.launch({
-    args: ['./dist/main/index.js'],
-  })
+  const buildFilePath = path.resolve(__dirname, '../dist/main/index.js')
 
-  // Evaluation expression in the Electron context.
-  const appPath = await electronApp.evaluate(async ({ app }) => {
-    // This runs in the main Electron process, parameter here is always
-    // the result of the require('electron') in the main app script.
-    return app.getAppPath()
-  })
+  // Dependency: Check if the file has been built
+  const appHasBuilt = ifFileExists(buildFilePath)
 
-  // Get the first window that the app opens, wait if necessary
-  const window = await electronApp.firstWindow()
+  if (appHasBuilt) {
+    // Launch Electron app.
+    const electronApp = await electron.launch({
+      args: [buildFilePath],
+    })
 
-  // Direct Electron console to Node terminal
-  window.on('console', console.log)
+    // Evaluation expression in the Electron context.
+    const appPath = await electronApp.evaluate(async ({ app }) => {
+      // This runs in the main Electron process, parameter here is always
+      // the result of the require('electron') in the main app script.
+      return app.getAppPath()
+    })
 
-  // Capture a screenshot
-  await window.screenshot({ path: 'screenshot.png' })
+    // Get the first window that the app opens, wait if necessary
+    const window = await electronApp.firstWindow()
 
-  // Exit app
-  await electronApp.close()
+    // Direct Electron console to Node terminal
+    window.on('console', console.log)
+
+    // Capture a screenshot
+    await window.screenshot({ path: 'screenshot.png' })
+
+    // Exit app
+    await electronApp.close()
+  } else {
+    console.error(
+      'The app has not yet been built. Please build the app first: yarn run dev.'
+    )
+  }
 })()
+
+function ifFileExists(filePath) {
+  return fs.promises
+    .access(filePath, fs.F_OK)
+    .then(() => true)
+    .catch(() => false)
+}

--- a/app/src/main/BrowserWinHandler.js
+++ b/app/src/main/BrowserWinHandler.js
@@ -38,6 +38,7 @@ export default class BrowserWinHandler {
   _create() {
     this.browserWindow = new BrowserWindow({
       ...this.options,
+      show: false, // hide until loaded
       webPreferences: {
         ...this.options.webPreferences,
         webSecurity: isProduction, // disable on dev to allow loading local resources
@@ -80,6 +81,9 @@ export default class BrowserWinHandler {
     const serverUrl = isDev ? DEV_SERVER_URL : 'app://./index.html'
     const fullPath = serverUrl + '#' + pagePath
     await this.browserWindow.loadURL(fullPath)
+
+    // After loading the web app, show the desktop app
+    this.browserWindow.show()
   }
 
   /**

--- a/app/src/main/mainWindow.js
+++ b/app/src/main/mainWindow.js
@@ -19,7 +19,6 @@ const winHandler = new BrowserWinHandler({
   width: 1200,
   useContentSize: true,
   backgroundColor: '#F5F5F5',
-  // show: false, // Shown when ready-to-show event fires
   webPreferences: {
     webviewTag: true, // Required
     nodeIntegration: true, // Required
@@ -30,8 +29,9 @@ const winHandler = new BrowserWinHandler({
   titleBarStyle: 'hiddenInset', // Hide the bar
 })
 
-winHandler.onCreated((browserWindow) => {
-  winHandler.loadPage('/')
+winHandler.onCreated(async (browserWindow) => {
+  // Load the app
+  await winHandler.loadPage('/')
   // if (isDev) browserWindow.loadURL(DEV_SERVER_URL)
   // else browserWindow.loadFile(INDEX_PATH)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,6 +2949,7 @@ __metadata:
     native-ext-loader: 2.3.0
     node-sass: 5.0.0
     nuxt: ^2.15.7
+    playwright: ^1.14.1
     playwright-core: ^1.13.1
     prettier: ^2.3.2
     sass-loader: 10.2.0
@@ -17730,6 +17731,30 @@ fsevents@^1.2.7:
   bin:
     playwright: lib/cli/cli.js
   checksum: 340c70457ffb90a9e40ddc6d6f718accf5e2cecb8bb116d7170ed86100e2d2a4b75b0574ef62163b41a5a5fa557976f96ff1942964a07c7c8471a345397414be
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.14.1":
+  version: 1.14.1
+  resolution: "playwright@npm:1.14.1"
+  dependencies:
+    commander: ^6.1.0
+    debug: ^4.1.1
+    extract-zip: ^2.0.1
+    https-proxy-agent: ^5.0.0
+    jpeg-js: ^0.4.2
+    mime: ^2.4.6
+    pngjs: ^5.0.0
+    progress: ^2.0.3
+    proper-lockfile: ^4.1.1
+    proxy-from-env: ^1.1.0
+    rimraf: ^3.0.2
+    stack-utils: ^2.0.3
+    ws: ^7.4.6
+    yazl: ^2.5.1
+  bin:
+    playwright: lib/cli/cli.js
+  checksum: 56badc619fbc8693ce27dc70fd68994a8a4c254c34e51dacf677a7923073be79c8c05aedd16bb31e78afa757a5335b1064bf1ecaf6b5384a98967fccf852ab6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds script for taking an automated screenshot of Reflex via Playwright. 

This could later allow for screenshots during CI builds (Mac, Windows), and for screen recordings of the app flow.