### PR TITLE
Only enable drag-to-reorder when edit mode is off

### DIFF
--- a/app/src/renderer/components/SidePanel/artboardEditable.vue
+++ b/app/src/renderer/components/SidePanel/artboardEditable.vue
@@ -3,6 +3,7 @@
     v-model="artboardsGetSet"
     :group="{ name: 'artboards', pull: true, put: true }"
     :animation="150"
+    :disabled="editMode === true"
   >
     <div v-for="artboard in artboards" :key="artboard.id" class="artboard-tab">
       <!-- Editing state -->


### PR DESCRIPTION
- User can drag-select text in input fields while in edit mode
- Drag-to-reorder screens still works when not in editing mode