### PR TITLE
Fix/release bumping

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "@reflex/app",
   "productName": "Reflex",
   "description": "Make responsive websites without the guesswork.",
-  "version": "0.7.0-beta.26",
+  "version": "0.7.0-beta.27",
   "author": "Nick Wittwer",
   "main": "./dist/main/index.js",
   "homepage": "https://reflexapp.nickwittwer.com",
@@ -133,5 +133,5 @@
     "webpack": "^4.46.0",
     "webpack-node-externals": "^2.5.2"
   },
-  "stableVersion": "0.7.0-beta.25"
+  "stableVersion": "0.7.0-beta.26"
 }

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
     "dev": "node .electron-nuxt/dev.js",
     "build": "npx cross-env RELEASE=true node .electron-nuxt/build.js",
     "build:fast": "node .electron-nuxt/build.js",
-    "release": "node --loader @esbuild-kit/esm-loader ./scripts/updater-cli.mjs",
+    "release": "npx @digitak/esrun --tsconfig=./scripts/tsconfig.json ./scripts/updater-cli.ts",
     "test": "jest",
     "lint": "eslint --ext .js,.vue,.ts -f eslint-friendly-formatter ./src",
     "lint:fix": "yarn run lint -- --fix",

--- a/app/scripts/tsconfig.json
+++ b/app/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+  }
+}

--- a/app/scripts/updater-cli.ts
+++ b/app/scripts/updater-cli.ts
@@ -74,13 +74,12 @@ async function inquireUpdateType() {
       // Use Yarn to bump the version
       await execaCommandAtRoot(`yarn version ${answers.updateType}`)
 
-      // Check the latest package.json to see if the vesion has been changed
-      const {
-        default: { version: updatedPackageVersion },
-      } = await import(path.resolve(pathToApp, 'package.json'), {
-        assert: {
-          type: 'json',
-        },
+      // Check updated package.json version
+      const updatedPackageVersion = await fs
+        .readFile(path.resolve(pathToApp, 'package.json'), 'utf-8')
+        .then((data) => {
+          const { version } = JSON.parse(data)
+          return version
       })
 
       // Ensure that the version has really been bumped


### PR DESCRIPTION
- Fixed the `yarn run release` script 
- Migrated script to TypeScript, and run the script using: `npx @digitak/esrun --tsconfig=./scripts/tsconfig.json ./scripts/updater-cli.ts`. The `@digitak/esrun` package provides an incredibly easy way to run `.ts` files which use ES6 syntax like `import`, without having to resort to using `.mjs` or setting the package.json `module` type. 