### PR TITLE
Adjust Panzoom origin to 0,0

### DIFF
--- a/app/src/renderer/components/SidePanel/artboardEditable.vue
+++ b/app/src/renderer/components/SidePanel/artboardEditable.vue
@@ -86,6 +86,7 @@ import rightClickMenu from '~/mixins/rightClickMenu'
 import { useArtboardsStore } from '~/store/artboards'
 import { useHoverArtboardsStore } from '~/store/hoverArtboards'
 import { useSelectedArtboardsStore } from '~/store/selectedArtboards'
+import { centerOn } from '~/components/panzoom/panzoomFns'
 
 export default {
   name: 'ArtboardEditable',
@@ -176,15 +177,18 @@ export default {
     },
     goToArtboard(id) {
       // Find the artboard (DOM)
-      const artboard = document.querySelector(`[artboard-id="${id}"]`)
+      const artboard = document.querySelector<HTMLElement>(
+        `[artboard-id="${id}"]`
+      )
       if (!artboard) {
         console.warn('No Artboard found')
         return false
       }
 
       // Pan to the position of the element relative to the parent
-      // TODO factor in the size of the artboard... Panzoom should scale down to fith the screen
-      this.$root.$panzoom.pan(-artboard.offsetLeft, artboard.offsetTop)
+      centerOn(artboard, {
+        instance: this.$root.$panzoom,
+      })
     },
     rightClickMenu(e, artboard) {
       rightClickMenu(this.$store, {

--- a/app/src/renderer/components/SidePanel/artboardEditable.vue
+++ b/app/src/renderer/components/SidePanel/artboardEditable.vue
@@ -86,7 +86,7 @@ import rightClickMenu from '~/mixins/rightClickMenu'
 import { useArtboardsStore } from '~/store/artboards'
 import { useHoverArtboardsStore } from '~/store/hoverArtboards'
 import { useSelectedArtboardsStore } from '~/store/selectedArtboards'
-import { centerOn } from '~/components/panzoom/panzoomFns'
+import { centerOnElement } from '~/components/panzoom/panzoomFns'
 
 export default {
   name: 'ArtboardEditable',
@@ -186,7 +186,7 @@ export default {
       }
 
       // Pan to the position of the element relative to the parent
-      centerOn(artboard, {
+      centerOnElement(artboard, {
         instance: this.$root.$panzoom,
       })
     },
@@ -210,6 +210,7 @@ export default {
     selectArtboard(id) {
       // Move screen to the selected artboard
       this.goToArtboard(id)
+
       // Remove all previous selections
       const selectedArtboards = useSelectedArtboardsStore()
       selectedArtboards.empty()

--- a/app/src/renderer/components/panzoom/Panzoom.vue
+++ b/app/src/renderer/components/panzoom/Panzoom.vue
@@ -46,7 +46,7 @@ import useEventHandler from '../Screens/useEventHandler'
 import { useDevStore } from '~/store/dev'
 import { isEqual } from 'lodash'
 import { start } from 'repl'
-import { initialPan } from './panzoomFns'
+import { initialPanZoom } from './panzoomFns'
 // import { useEventListener } from '@vueuse/core'
 
 const interactions = useInteractionStore()
@@ -82,9 +82,9 @@ onMounted(async () => {
   if (!$root) console.warn('No Panzoom created')
 
   // const startZoom = initialZoom()
-  const { x: startX } = initialPan()
-  const { y: startY } = initialPan()
-  const { zoom: startZoom } = initialPan()
+  const { x: startX } = initialPanZoom()
+  const { y: startY } = initialPanZoom()
+  const { zoom: startZoom } = initialPanZoom()
 
   // Init Panzoom globally
   // We use the 'canvas' option to enable interactions on the parent DOM Node as well

--- a/app/src/renderer/components/panzoom/Panzoom.vue
+++ b/app/src/renderer/components/panzoom/Panzoom.vue
@@ -94,7 +94,8 @@ onMounted(async () => {
     cursor: 'grab',
     // origin = transform-origin is the origin from which transforms are applied
     // Default: 50% 50% https://github.com/timmywil/panzoom#origin
-    origin: '50% 50%',
+    origin: '0 0',
+    // origin: '0 0',
     startX: startX, // x
     startY: startY, // y
     // contain: false,

--- a/app/src/renderer/components/panzoom/Panzoom.vue
+++ b/app/src/renderer/components/panzoom/Panzoom.vue
@@ -211,7 +211,7 @@ function enableEventListeners() {
  * @param DOMElement DOM element that Panzoom is on
  * @param instance The Panzoom instance
  */
-function wheelHandler(DOMElement, instance) {
+function wheelHandler(DOMElement, instance: PanzoomObject) {
   DOMElement.addEventListener('wheel', onWheel)
 
   function onWheel(event) {
@@ -222,10 +222,284 @@ function wheelHandler(DOMElement, instance) {
     // Prevent default scroll event
     event.preventDefault()
 
+    // Normalize to deltaX in case shift modifier is used on Mac
+    const delta =
+      event.deltaY === 0 && event.deltaX ? event.deltaX : event.deltaY
+    const wheel = delta < 0 ? 1 : -1
+
     // Require the CMD/CTRL key to be pressed
     // This prevents accidental scrolling
     if (event.ctrlKey || event.metaKey || event.altKey) {
-      instance.zoomWithWheel(event)
+      // If we were using transform-origin 50%,50% on the Panzoom class we could use instance.zoomWithWheel and be done with it
+      // instance.zoomWithWheel(event)
+      // But we are using origin 0,0 so we need to do this manually
+      // Docs: https://github.com/timmywil/panzoom#zoomtopoint
+      // https://github.com/timmywil/panzoom/issues/482#issuecomment-621933139
+      // https://github.com/timmywil/panzoom/issues/630#issuecomment-1419893403
+      // https://github.com/timmywil/panzoom/issues/564#issuecomment-832791748
+      // https://github.com/timmywil/panzoom/issues/555
+      // https://github.com/timmywil/panzoom/blob/7428761452cfb570a7ebf7e5d6d7cd18b1893ee2/src/panzoom.ts#L349
+
+      function convertClientPointToPanzoomViewport() {
+        // We receive a clientX and clientY from the event
+        // We need to convert this to a point relative to the Panzoom viewport
+        // This is because Panzoom uses the viewport as its origin
+        // We can do this by using the Panzoom instance's getBoundingClientRect method
+        const { el: viewport, rect: viewportRect } =
+          getPanzoomElement('viewport')
+        if (!viewport) return { x: 0, y: 0 }
+
+        // We need to subtract the Panzoom viewport's offset from the event's X/Y
+        // We calculate all the size outside the Panzoom Viewport and subtract it from the event's X/Y
+        const rootElement = document.body
+        const rootRect = rootElement.getBoundingClientRect()
+        // rootRect.height = rootRect.height - viewportRect.height
+        // rootRect.width = rootRect.width - viewportRect.width
+
+        console.log(rootElement, viewport)
+
+        console.log(rootRect.height, viewportRect.height)
+
+        const x = event.clientX - (rootRect.width - viewportRect.width)
+        const y = event.clientY - (rootRect.height - viewportRect.height)
+
+        return { x, y }
+      }
+
+      // const scale = instance.getScale()
+      // const toScale = scale * Math.exp(wheel / 3)
+      // const toScale = scale * Math.exp(wheel / 30)
+
+      // Calculate the new zoom level based on the wheel delta
+      // const delta = event.deltaY || event.detail || event.wheelDelta
+      // const delta =
+      //   event.deltaY === 0 && event.deltaX ? event.deltaX : event.deltaY
+
+      // const zoomDelta = delta ? delta / 10000 : 0 // TODO: Make the value smaller to zoom faster
+      // const zoomLevel = panzoomInstance.value?.getScale() + zoomDelta
+
+      // Calculate the center point of the viewport
+      const { el: viewport, rect: viewportRect } = getPanzoomElement('viewport')
+      const { el: container, rect: containerRect } =
+        getPanzoomElement('container')
+      if (!viewport || !container) return false
+
+      ////////////////
+
+      // Calculate the zoom scale
+      const delta = Math.max(-1, Math.min(1, event.deltaY))
+      // const zoomScale = Math.pow(1.2, delta)
+      const prevScale = instance.getScale()
+      let newScale = prevScale + delta / 100
+      newScale = Math.max(newScale, minScale) // Ensure the scale never goes below 0.001
+
+      // const deltaX =
+      //   (event.clientX - container.offsetLeft) * (1 / prevScale - 1 / newScale)
+      // const deltaY =
+      //   (event.clientY - container.offsetTop) * (1 / prevScale - 1 / newScale)
+      // const newX = instance.getPan().x - deltaX
+      // const newY = instance.getPan().y - deltaY
+      const currPan = {
+        x: instance.getPan().x,
+        y: instance.getPan().y,
+      }
+
+      // calculate the new pan position to keep the mouse centered
+      const zoomFactor = newScale / prevScale
+      const mouse = {
+        x: event.clientX,
+        y: event.clientY,
+      }
+
+      // const offset = {
+      //   x: mouse.x - containerRect.left - currPan.x * prevScale,
+      //   y: mouse.y - containerRect.top - currPan.y * prevScale,
+      // }
+      // const newPan = {
+      //   x: currPan.x - offset.x * delta,
+      //   y: currPan.y - offset.y * delta,
+      // }
+
+      // const offsetX = mouseOffset.x - viewport.offsetWidth / 2
+      // const offsetY = mouseOffset.y - viewport.offsetHeight / 2
+      // const panX =
+      //   instance.getPan().x -
+      //   offsetX * (newScale / prevScale - 1) +
+      //   ((container.offsetWidth - viewport.offsetWidth) / 2) *
+      //     (newScale / prevScale)
+      // const panY = instance.getPan().y - offsetY * (newScale / prevScale - 1)
+
+      // `focal` is a low-level option for focusing in on a point of the element,
+      // not relative to the parent dimensions.
+      // But zooming the way we usually think about it is often relative to parent dimensions
+      // and not the element, which is why Panzoom has the zoomToPoint method to make things easier.
+      // Setting the focal to the existing transform doesn't work, as those numbers aren't really related.
+      // Original `focal` implementation: https://github.com/timmywil/panzoom/blob/7428761452cfb570a7ebf7e5d6d7cd18b1893ee2/src/panzoom.ts#LL401C5-L404C6
+      // This assumes the transform-origin is 50%,50%
+      // In our case, the transform-origin is 0,0
+      // const focal = {
+      //   x: (mouse.x / viewportRect.width) * (viewportRect.width * newScale),
+      //   y: (mouse.y / viewportRect.height) * (viewportRect.height * newScale),
+      // }
+
+      ///////////////
+      // const viewportCenter = {
+      //   x: viewportRect.width / 2,
+      //   y: viewportRect.height / 2,
+      // }
+      // const containerCenter = {
+      //   x: containerRect.width / 2,
+      //   y: containerRect.height / 2,
+      // }
+      // const focal = {
+      //   x: (mouse.x / viewportCenter.x) * (containerCenter.x * newScale),
+      //   y: (mouse.y / viewportCenter.y) * (containerCenter.y * newScale),
+      // }
+      ///////////////
+      // const mouseOffset = {
+      //   x: mouse.x - containerRect.left - containerRect.width / 2,
+      //   y: mouse.y - containerRect.top - containerRect.height / 2,
+      // }
+
+      // console.log(container)
+      console.log(mouse.x - containerRect.left, mouse.y - containerRect.top)
+
+      const mouseOffset = {
+        x: mouse.x - containerRect.left - containerRect.width / 2,
+        y: mouse.y - containerRect.top - containerRect.height / 2,
+      }
+      // console.log('mouseOffset', mouseOffset)
+
+      // Calculate the focal point relative to the container element
+      // Convert the mouse point from it's position over the
+      // effective area before the scale to the position
+      // over the effective area after the scale.
+      const focal = {
+        x: (mouse.x - mouseOffset.x) * prevScale,
+        y: (mouse.y - mouseOffset.y) * prevScale,
+      }
+
+      // The difference between the point after the scale and the point before the scale
+      // plus the current translation after the scale
+      // neutralized to no scale (as the transform scale will apply to the translation)
+      const focal2 = {
+        x:
+          (focal.x / newScale - focal.x / prevScale + currPan.x * newScale) /
+          newScale,
+        y:
+          (focal.y / newScale - focal.y / prevScale + currPan.y * newScale) /
+          newScale,
+      }
+
+      // const focal = {
+      //   x: (viewportRect.width / 2 - mouseOffset.x) * newScale,
+      //   y: (viewportRect.height / 2 - mouseOffset.y) * newScale,
+      // }
+
+      instance.zoom(newScale, {
+        animate: true,
+        focal: focal,
+      })
+
+      // instance.pan(newPan.x, newPan.y, {
+      //   animate: true,
+      //   relative: true,
+      // })
+
+      // Pan relative to the current position
+      // instance.pan(newPan.x, newPan.y, { relative: true })
+      // instance.pan(newPan.x, newPan.y)
+
+      const table = {
+        scale: {
+          prev: prevScale,
+          new: newScale,
+        },
+        mouseX: {
+          prev: mouse.x,
+          new: mouseOffsetX,
+        },
+        mouseY: {
+          prev: mouse.y,
+          new: mouseOffsetY,
+        },
+        panX: {
+          prev: currPan.x,
+          new: newPanX,
+        },
+        panY: {
+          prev: currPan.y,
+          new: newPanY,
+        },
+      }
+
+      console.table(table)
+
+      ////////////////
+
+      // // Get the current x, y, and scale
+      // const { x: currX, y: currY } = instance.getPan()
+      // const currScale = instance.getScale()
+
+      // // Get the position and dimensions of the container element
+      // const left = container.offsetLeft
+      // const top = container.offsetTop
+      // const width = container.offsetWidth
+      // const height = container.offsetHeight
+
+      // // Get the position of the mouse in the viewport
+      // const mouseX = event.clientX
+      // const mouseY = event.clientY
+
+      // // Calculate the new scale based on the wheel delta
+      // // Normalize to deltaX in case shift modifier is used on Mac
+      // const delta =
+      //   event.deltaY === 0 && event.deltaX ? event.deltaX : event.deltaY
+      // const zoomLevel = delta / 1000
+      // const newScale = currScale + zoomLevel
+
+      // // Get the size of the viewport element
+      // const viewportWidth = viewport.clientWidth
+      // const viewportHeight = viewport.clientHeight
+
+      // // Calculate the difference between the current mouse position and the center of the viewport
+      // const diffX = (viewportWidth / 2 - currX - event.clientX) / currScale
+      // const diffY = (viewportHeight / 2 - currY - event.clientY) / currScale
+
+      // // Calculate the new x and y position of the container element
+      // const newLeft = container.offsetLeft - diffX * newScale
+      // const newTop = container.offsetTop - diffY * newScale
+
+      // // Pan and zoom to the new position and scale
+      // instance.pan(newLeft, newTop)
+      // instance.zoom(newScale, { animate: true })
+
+      ////////////////
+
+      /////////
+      // const targetX = event.clientX - viewport.offsetLeft
+      // const targetY = event.clientY - viewport.offsetTop
+      // const currentPan = panzoomInstance.value.getPan()
+      // const viewportX =
+      //   (targetX - currentPan.x) / panzoomInstance.value.getScale()
+      // const viewportY =
+      //   (targetY - currentPan.y) / panzoomInstance.value.getScale()
+      /////////
+
+      // instance.zoomToPoint(
+      //   zoomLevel,
+      //   {
+      //     clientX: viewportX,
+      //     clientY: viewportY,
+      //   },
+      //   { animate: true, transformOrigin: { x: 0, y: 0 } }
+      // )
+
+      // Adjust the pan position to keep the zoom centered on the mouse position
+      // instance.pan(offsetLeft, offsetTop)
+
+      // instance.zoom(toScale)
+      // instance.pan(x, y)
     } else {
       // Allow trackpads to pan using two fingers
       const currentPan = instance.getPan()

--- a/app/src/renderer/components/panzoom/Panzoom.vue
+++ b/app/src/renderer/components/panzoom/Panzoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="display: inline-block">
+  <div style="display: inline-block; width: 100%; height: 100%">
     <!-- We 'panzoom-exclude' to mark this as not relevant to Panzoom -->
     <!-- <PanzoomControls v-if="panzoomInstance" :instance="panzoomInstance" /> -->
     <div
@@ -10,13 +10,26 @@
         'dev-visual-debugger': showCanvasDebugger,
       }"
     >
+      <!-- For transform-origin: 50% 50% to work, this next element HAS to be display:block -->
       <div
         ref="innerPanArea"
-        :class="{
-          'dev-visual-debugger': showCanvasDebugger,
-        }"
+        style="
+          display: block;
+          position: relative;
+          height: 100%;
+          width: 100%;
+          overflow: visible;
+        "
       >
-        <slot />
+        <!-- Now we have the real panzoom content inside: -->
+        <div
+          class="panzoom-inner"
+          :class="{
+            'dev-visual-debugger': showCanvasDebugger,
+          }"
+        >
+          <slot />
+        </div>
       </div>
     </div>
   </div>
@@ -31,6 +44,9 @@ import PanzoomControls from './PanzoomControls.vue'
 import { useInteractionStore } from '~/store/interactions'
 import useEventHandler from '../Screens/useEventHandler'
 import { useDevStore } from '~/store/dev'
+import { isEqual } from 'lodash'
+import { start } from 'repl'
+import { initialPan } from './panzoomFns'
 // import { useEventListener } from '@vueuse/core'
 
 const interactions = useInteractionStore()
@@ -38,8 +54,7 @@ const devStore = useDevStore()
 const { state: userEventsState } = useEventHandler()
 
 // Store
-// const showCanvasDebugger = false // TODO: Migrate from Vuex -> Pinia
-const showCanvasDebugger = devStore.showCanvasDebugger
+const showCanvasDebugger = computed(() => devStore.showCanvasDebugger)
 const panzoomEnabled = computed(() => interactions.panzoomEnabled)
 const isInteracting = computed(() => interactions.isInteracting)
 
@@ -66,14 +81,24 @@ onMounted(async () => {
   const { $root } = getCurrentInstance()?.proxy
   if (!$root) console.warn('No Panzoom created')
 
+  // const startZoom = initialZoom()
+  const { x: startX } = initialPan()
+  const { y: startY } = initialPan()
+  const { zoom: startZoom } = initialPan()
+
   // Init Panzoom globally
   // We use the 'canvas' option to enable interactions on the parent DOM Node as well
   // Docs: https://github.com/timmywil/panzoom#canvas
   $root.$panzoom = Panzoom(innerPanArea.value, {
     canvas: true, // Allows parent to control child
     cursor: 'grab',
-    startScale: 1,
-    startX: 0,
+    // origin = transform-origin is the origin from which transforms are applied
+    // Default: 50% 50% https://github.com/timmywil/panzoom#origin
+    origin: '50% 50%',
+    startX: startX, // x
+    startY: startY, // y
+    // contain: false,
+    startScale: startZoom,
     handleStartEvent: (event: PointerEvent) => {
       // WARNING: Don't use preventDefault, as it will block other events
       // event.preventDefault()
@@ -99,14 +124,22 @@ onMounted(async () => {
   // Reference inside of this component
   panzoomInstance.value = $root.$panzoom
 
-  // Center Panzoom
-  // this.panzoomInstance.pan(
-  //   origX + (current.clientX - startClientX) / scale,
-  //   origY + (current.clientY - startClientY) / scale,
-  //   {
-  //     animate: false,
+  // TODO: Remove later; useful for debugging
+  // let zoom, pan
+  // setInterval(() => {
+  //   const newZoom = panzoomInstance.value?.getScale()
+  //   const newPan = panzoomInstance.value?.getPan()
+
+  //   const isNewZoom = zoom !== newZoom
+  //   const isNewPan = isEqual(pan, newPan) === false
+
+  //   if (isNewZoom) zoom = newZoom
+  //   if (isNewPan) pan = newPan
+
+  //   if (isNewPan || isNewZoom) {
+  //     console.log('Panzoom', { zoom, ...pan }, isNewZoom, isNewPan)
   //   }
-  // )
+  // }, 1000)
 
   // Enable event listeners
   enableEventListeners()
@@ -263,16 +296,18 @@ function fitToScreen() {
 
 <style lang="scss" scoped>
 .panzoom-container {
-  // position: absolute;
-  // overflow: hidden;
-  // outline: none;
+  position: relative !important;
   height: 100%;
   width: 100%;
-  position: relative;
-  // position: absolute;
   top: 0;
   left: 0;
   overflow: hidden;
+}
+
+.panzoom-inner {
+  position: relative; // Important
+  display: inline-block;
+  overflow: visible;
 }
 
 #parent {
@@ -318,14 +353,22 @@ function fitToScreen() {
   .dev-visual-debugger {
     // Vertical line
     &:before {
+      position: absolute;
+      width: 100%;
+      z-index: 100;
+      height: 100%;
       left: 50%;
-      border-left: 1px solid green;
+      border-left: 5px solid green;
     }
 
     // Horizonal line
     &:after {
+      position: absolute;
+      width: 100%;
+      z-index: 100;
+      height: 100%;
       top: 50%;
-      border-top: 1px solid green;
+      border-top: 5px solid green;
     }
   }
 }

--- a/app/src/renderer/components/panzoom/Panzoom.vue
+++ b/app/src/renderer/components/panzoom/Panzoom.vue
@@ -17,8 +17,8 @@
         style="
           display: block;
           position: relative;
-          height: 100%;
-          width: 100%;
+          /* height: 100%; */
+          /* width: 100%; */
           overflow: visible;
         "
       >
@@ -98,8 +98,8 @@ onMounted(async () => {
     // origin: '0 0',
     startX: startX, // x
     startY: startY, // y
-    // contain: false,
     startScale: startZoom,
+    // contain: false,
     handleStartEvent: (event: PointerEvent) => {
       // WARNING: Don't use preventDefault, as it will block other events
       // event.preventDefault()

--- a/app/src/renderer/components/panzoom/Panzoom.vue
+++ b/app/src/renderer/components/panzoom/Panzoom.vue
@@ -2,6 +2,7 @@
   <div style="display: inline-block; width: 100%; height: 100%">
     <!-- We 'panzoom-exclude' to mark this as not relevant to Panzoom -->
     <!-- <PanzoomControls v-if="panzoomInstance" :instance="panzoomInstance" /> -->
+    <div class="dev"></div>
     <div
       id="canvas"
       ref="outerPanArea"
@@ -45,7 +46,6 @@ import { useInteractionStore } from '~/store/interactions'
 import useEventHandler from '../Screens/useEventHandler'
 import { useDevStore } from '~/store/dev'
 import { isEqual } from 'lodash'
-import { start } from 'repl'
 import { initialPanZoom } from './panzoomFns'
 // import { useEventListener } from '@vueuse/core'
 
@@ -78,7 +78,7 @@ watch(panzoomEnabled, (newVal) => {
 
 onMounted(async () => {
   // TODO: This should be refactored after Vue 3 update
-  const { $root } = getCurrentInstance()?.proxy
+  const { $root, $config } = getCurrentInstance()?.proxy
   if (!$root) console.warn('No Panzoom created')
 
   // const startZoom = initialZoom()
@@ -126,21 +126,24 @@ onMounted(async () => {
   panzoomInstance.value = $root.$panzoom
 
   // TODO: Remove later; useful for debugging
-  // let zoom, pan
-  // setInterval(() => {
-  //   const newZoom = panzoomInstance.value?.getScale()
-  //   const newPan = panzoomInstance.value?.getPan()
+  const isDev = $config?.DEV
+  if (isDev) {
+    let zoom, pan
+    setInterval(() => {
+      const currZoom = panzoomInstance.value?.getScale()
+      const currPan = panzoomInstance.value?.getPan()
 
-  //   const isNewZoom = zoom !== newZoom
-  //   const isNewPan = isEqual(pan, newPan) === false
+      const isNewZoom = zoom !== currZoom
+      const isNewPan = isEqual(pan, currPan) === false
 
-  //   if (isNewZoom) zoom = newZoom
-  //   if (isNewPan) pan = newPan
+      if (isNewZoom) zoom = currZoom
+      if (isNewPan) pan = currPan
 
-  //   if (isNewPan || isNewZoom) {
-  //     console.log('Panzoom', { zoom, ...pan }, isNewZoom, isNewPan)
-  //   }
-  // }, 1000)
+      if (isNewPan || isNewZoom) {
+        console.log('Panzoom', { zoom, ...pan }, isNewZoom, isNewPan)
+      }
+    }, 1000)
+  }
 
   // Enable event listeners
   enableEventListeners()
@@ -352,10 +355,12 @@ function fitToScreen() {
 
   // Nested debugger
   .dev-visual-debugger {
+    box-shadow: 0 0 0 8px green;
+
     // Vertical line
     &:before {
       position: absolute;
-      width: 100%;
+      width: 50%;
       z-index: 100;
       height: 100%;
       left: 50%;
@@ -367,7 +372,7 @@ function fitToScreen() {
       position: absolute;
       width: 100%;
       z-index: 100;
-      height: 100%;
+      height: 50%;
       top: 50%;
       border-top: 5px solid green;
     }

--- a/app/src/renderer/components/panzoom/Panzoom.vue
+++ b/app/src/renderer/components/panzoom/Panzoom.vue
@@ -46,7 +46,7 @@ import { useInteractionStore } from '~/store/interactions'
 import useEventHandler from '../Screens/useEventHandler'
 import { useDevStore } from '~/store/dev'
 import { isEqual } from 'lodash'
-import { initialPanZoom } from './panzoomFns'
+import { initialPanZoom, getPanzoomElement, minScale } from './panzoomFns'
 // import { useEventListener } from '@vueuse/core'
 
 const interactions = useInteractionStore()
@@ -96,6 +96,7 @@ onMounted(async () => {
     // Default: 50% 50% https://github.com/timmywil/panzoom#origin
     origin: '0 0',
     // origin: '0 0',
+    minScale: minScale,
     startX: startX, // x
     startY: startY, // y
     startScale: startZoom,

--- a/app/src/renderer/components/panzoom/panzoomFns.ts
+++ b/app/src/renderer/components/panzoom/panzoomFns.ts
@@ -6,6 +6,7 @@ import Panzoom, { PanzoomObject } from '@panzoom/panzoom'
 const panzoomContainer = '.panzoom-container'
 const panzoomChild = '.panzoom-inner'
 const zoomPadding = 0.25
+export const minScale = 0.001
 
 function getPanzoomElement(name: 'viewport' | 'container') {
   const viewport = document.querySelector(panzoomContainer) as HTMLElement

--- a/app/src/renderer/components/panzoom/panzoomFns.ts
+++ b/app/src/renderer/components/panzoom/panzoomFns.ts
@@ -31,6 +31,271 @@ export function initialPanZoom() {
     zoom: zoom,
   }
 }
+export function centerOn(element: HTMLElement, options: { instance: any }) {
+  // Get the position and dimensions of the element relative to the viewport.
+  // Then you can calculate the center point of the element by adding half of the width and height to its top-left position
+  // Then subtract the position of the parent element to get the center relative to its parent.
+  // const parent = document.querySelector<HTMLElement>(panzoomContainer)
+  const parent = document.querySelector<HTMLElement>(panzoomContainer)
+  // const parent = document.documentElement
+  if (!parent) {
+    console.error('No container')
+    return {}
+  }
+  // Calculate the position of the element relative to the parent container
+  const parentRect = parent.getBoundingClientRect()
+
+  // Get the full size of the artboards container (panzoomChild)
+  const container = element.closest(panzoomChild) as HTMLElement
+  if (!container) return false
+  const containerRect = container.getBoundingClientRect()
+
+  // Get the element's bounding rectangle relative to the viewport
+  const child = element
+  const childRect = child.getBoundingClientRect()
+
+  /////////////
+
+  // Calculate the center point of the element
+
+  // const containerCenterX = containerRect.left + containerRect.width / 2
+  // const containerCenterY = containerRect.top + containerRect.height / 2
+  // const childCenterX = childRect.left + childRect.width / 2
+  // const childCenterY = childRect.top + childRect.height / 2
+  // const dx = containerCenterX - childCenterX
+  // const dy = containerCenterY - childCenterY
+  // const distance = Math.sqrt(dx * dx + dy * dy)
+  // const intensity = Math.min(1, distance / (containerRect.width / 2))
+  // const factorX = dx * intensity * (childRect.width / containerRect.width)
+  // const factorY = dy * intensity * (childRect.height / containerRect.height)
+  // const centerX =
+  //   (parentRect.width - childRect.width) / 2 +
+  //   containerRect.left -
+  //   childRect.left +
+  //   factorX
+  // const centerY =
+  //   (parentRect.height - childRect.height) / 2 +
+  //   containerRect.top -
+  //   childRect.top +
+  //   factorY
+
+  // console.log('Distance', distance)
+
+  ///////////////
+  // const containerWidth = container.clientWidth
+  // const containerHeight = container.clientHeight
+  // const centerX =
+  //   (parentRect.width - containerRect.width + childRect.width) / 2 -
+  //   childRect.left
+  // const centerY =
+  //   (parentRect.height - containerRect.height + childRect.height) / 2 -
+  //   childRect.top
+
+  // console.log('centerX:', centerX)
+  // console.log('centerY:', centerY)
+  ////////////
+
+  // const centerX = (parentRect.width - childRect.width) / 2 - childRect.left
+  // const centerY = (parentRect.height - childRect.height) / 2 - childRect.top
+
+  // Calculate the zoom scale
+  // const panzoomViewportRect = {
+  //   width: parent.offsetWidth,
+  //   height: parent.offsetHeight,
+  // }
+  // const zoom = zoomToFitElement(element)
+  // const zoom = options.instance.getScale()
+  // if (!zoom) return false
+
+  // TODO: Include window.devicePixelRatio?
+
+  // var viewportWidth = parentRect.width
+  // var viewportHeight = parentRect.height
+  // var childWidth = childRect.width * zoom // We want to use the rendered width
+  // var childHeight = childRect.height * zoom // We want to use the rendered height
+  // var childX = (childRect.left - parentRect.left) / zoom
+  // var childY = (childRect.top - parentRect.top) / zoom
+  // var minX = Math.max(0, childWidth / 2 - parentRect.width / 2 - childX)
+  // var minY = Math.max(0, childHeight / 2 - parentRect.height / 2 - childY)
+  // var centerX = parentRect.width / 2 - childWidth / 2 + minX
+  // var centerY = parentRect.height / 2 - childHeight / 2 + minY
+
+  // const centerX = parentRect.left + parentRect.width / 2
+  // const centerY = parentRect.top + parentRect.height / 2
+
+  // const offsetX =
+  //   centerX -
+  //   (childRect.left + childRect.width / 2) -
+  //   (childRect.width - parentRect.width) / 2
+  // const offsetY =
+  //   centerY -
+  //   (childRect.top + childRect.height / 2) -
+  //   (childRect.height - parentRect.height) / 2
+
+  // // const centerXOnScreen = window.innerWidth / 2 - parentRect.left - parentRect.width / 2 + offsetX;
+  // // const centerYOnScreen = window.innerHeight / 2 - parentRect.top - parentRect.height / 2 + offsetY;
+
+  // console.log(parent, element.closest(panzoomChild), element) // Elements
+  // console.log(zoom, centerX, centerY, { child, container }) // Output
+  // options.instance.pan(offsetX, offsetY)
+
+  ////////////////////////////////
+
+  console.log('Test', {
+    parent: parent,
+    container: container,
+    child: child,
+  })
+
+  // Current settings
+  const zoom = options.instance.getScale()
+  if (!zoom) return false
+
+  // Get the viewport dimensions in pixels
+  const viewportWidth = parent.offsetWidth
+  const viewportHeight = parent.offsetHeight
+  // const viewportWidth = parentRect.width
+  // const viewportHeight = parentRect.height
+
+  // Get the offset from the container element
+  // const containerOffsetLeft = childRect.left
+  // const containerOffsetTop = childRect.top
+  const containerOffsetLeft = child.offsetLeft * zoom
+  const containerOffsetTop = child.offsetTop * zoom
+  console.log('offset', containerOffsetLeft, containerOffsetTop)
+
+  console.log('viewportWidth:', viewportWidth)
+  console.log('viewportHeight:', viewportHeight)
+  console.log('containerOffsetLeft:', containerOffsetLeft)
+  console.log('containerOffsetTop:', containerOffsetTop)
+
+  // Calculate the center point of the viewport, adjusted for the container offset
+  // Factor in the zoom level
+  // const viewportCenterX = viewportWidth / 2 - containerOffsetLeft
+  // const viewportCenterY = viewportHeight / 2 - containerOffsetTop
+  const viewportCenterX = (viewportWidth / 2 - containerOffsetLeft) / zoom
+  const viewportCenterY = (viewportHeight / 2 - containerOffsetTop) / zoom
+
+  console.log('viewportCenterX:', viewportCenterX)
+  console.log('viewportCenterY:', viewportCenterY)
+
+  // Set the position of the element to the adjusted center point of the viewport
+  // const elementWidth = childRect.width
+  // const elementHeight = childRect.height
+  const elementWidth = child.offsetWidth
+  const elementHeight = child.offsetHeight
+  // const elementWidth = parseFloat(getComputedStyle(element).width)
+  // const elementHeight = parseFloat(getComputedStyle(element).height)
+
+  console.log('elementWidth:', elementWidth)
+  console.log('elementHeight:', elementHeight)
+
+  // Final position
+  const x = viewportCenterX - elementWidth / 2
+  const y = viewportCenterY - elementHeight / 2
+
+  console.log('x:', x)
+  console.log('y:', y)
+
+  // Normally, we pan relative to the container
+  // But we want to pan relative to a specific element, so we can
+  // set our own transform values to be more specific
+  // options.instance.setTransform()
+  options.instance.setStyle(
+    'transform',
+    `scale(${zoom}) translate(${x}px, ${y}px)`
+  )
+  console.log()
+
+  // options.instance.pan(x, y)
+  ////////////////////////////////
+
+  // options.instance.zoom(zoom)
+
+  // Firstly calculate the offset of the element relative to the parent
+  // The first artboard is always 0,0
+  // NOTE: other elements are always negative, because the elements are on the right. Positive values are on the left.
+  // Then, subtract the width and height of the element (including padding, border, and margin)
+  // NOTE: Use .getBoundingClientRect() to because it returns the rendered size of the element (incl. CSS transforms)
+  // Use .offsetLeft/offsetTop to get position which Panzoom uses
+  // Finally, we get the difference of the parent and container width/height
+
+  // const elWidth = child.offsetWidth / 2
+  // const elHeight = child.offsetHeight / 2
+  // // const elWidth = childRect.width / 2
+  // // const elHeight = childRect.height / 2
+  // console.log(elWidth)
+
+  // const arbitraryX =
+
+  // // const parentDiff = container.offsetLeft - parent.offsetLeft
+  // const parentDiff = containerRect.left - parentRect.left
+  // // const parentDiff = containerRect.left
+  // // const parentDiff = containerRect.left
+  // console.log(parentDiff)
+
+  // let negativeX, negativeY
+  // child.offsetLeft === 0 ? (negativeX = false) : (negativeX = true)
+  // child.offsetTop === 0 ? (negativeY = false) : (negativeY = true)
+
+  // let newX, newY
+  // newX = child.offsetLeft + elWidth
+  // newY = child.offsetTop - elHeight
+
+  // if (negativeX) {
+  //   console.log('Negative X')
+  //   newX = -newX
+  // }
+  // if (negativeY) {
+  //   console.log('Negative Y')
+  //   newX = -newY
+  // }
+
+  // console.log(newX, newY, { element, container, parent })
+  // options.instance.pan(newX, newY)
+  // options.instance.pan(newX, newY)
+  // setTimeout(() => options.instance.zoom(zoom))
+
+  // options.instance.zoom(zoom)
+
+  // options.instance.zoomToPoint(zoom, {
+  //   clientX: centerX,
+  //   clientY: centerY,
+  // })
+
+  // const panzoomEl = document.querySelector<HTMLElement>(panzoomContainer)
+  // if (!panzoomEl) {
+  //   console.error('No container')
+  //   return {}
+  // }
+  // // const childElement = panzoomEl?.querySelector(panzoomChild) as HTMLElement
+  // const childElement = element.closest(panzoomChild) as HTMLElement
+  // console.log(childElement)
+
+  // const panzoomRect = panzoomEl.getBoundingClientRect()
+  // const childRect = childElement.getBoundingClientRect()
+
+  // const panzoomViewportRect = {
+  //   width: panzoomEl.offsetWidth,
+  //   height: panzoomEl.offsetHeight,
+  // }
+  // const childWidth = childRect.width
+  // const childHeight = childRect.height
+
+  // // Calculate the zoom scale
+  // const zoomPadding = 0.9 // add extra space on sides of the content
+  // const zoomX = (panzoomViewportRect.width / childWidth) * zoomPadding
+  // const zoomY = (panzoomViewportRect.height / childHeight) * zoomPadding
+  // const zoom = Math.min(zoomX, zoomY)
+
+  // // Pan
+  // const panX = (panzoomRect.width - childRect.width) / 2 - childRect.left
+  // const panY = (panzoomRect.height - childRect.height) / 2 - childRect.top
+
+  // // center child element within viewport
+  // options.instance.pan(panX, panY)
+  // options.instance.zoom(zoom)
+}
 /**
  * Returns a zoom factor which would fit all the current artboards within the viewport
  */

--- a/app/src/renderer/components/panzoom/panzoomFns.ts
+++ b/app/src/renderer/components/panzoom/panzoomFns.ts
@@ -1,28 +1,55 @@
 // The CSS classes
+
+import Panzoom, { PanzoomObject } from '@panzoom/panzoom'
+
 // TODO: Add tests to make sure these don't break
 const panzoomContainer = '.panzoom-container'
 const panzoomChild = '.panzoom-inner'
+
+function getPanzoomElement(name: 'viewport' | 'container') {
+  const viewport = document.querySelector(panzoomContainer) as HTMLElement
+  if (!viewport) {
+    console.error('No container')
+    return {}
+  }
+  // Calculate the position of the element relative to the viewport container
+  const viewportRect = viewport.getBoundingClientRect()
+
+  // Get the full size of the artboards container (panzoomChild)
+  const container = document.querySelector(panzoomChild) as HTMLElement
+  if (!container) return {}
+  const containerRect = container.getBoundingClientRect()
+
+  let element: HTMLElement
+  let elementRect: DOMRect
+
+  if (name === 'container') {
+    element = container
+    elementRect = containerRect
+  } else {
+    element = viewport
+    elementRect = viewportRect
+  }
+
+  // Always return an HTML Element and a bounding rectangle
+  return {
+    el: element,
+    rect: elementRect,
+  }
+}
 
 /**
  * Returns the x, y, zoom for the initial app startup
  */
 export function initialPanZoom() {
-  const panzoomEl = document.querySelector<HTMLElement>(panzoomContainer)
-  if (!panzoomEl) {
-    console.error('No container')
-    return {}
-  }
-  const childElement = panzoomEl?.querySelector(panzoomChild) as HTMLElement
-
-  const panzoomRect = panzoomEl.getBoundingClientRect()
-  const childRect = childElement.getBoundingClientRect()
+  const { el: parent } = getPanzoomElement('viewport')
+  const childElement = parent?.querySelector(panzoomChild) as HTMLElement
 
   // Calculate the zoom to fit all artboards
   const zoom = calculateZoomToFitAll()
 
   // Pan
-  const panX = (panzoomRect.width - childRect.width) / 2 - childRect.left
-  const panY = (panzoomRect.height - childRect.height) / 2 - childRect.top
+  const { x: panX, y: panY } = getCenterCoordinates(childElement, zoom)
 
   // center child element within viewport
   return {
@@ -31,6 +58,7 @@ export function initialPanZoom() {
     zoom: zoom,
   }
 }
+
 export function centerOn(element: HTMLElement, options: { instance: any }) {
   // Get the position and dimensions of the element relative to the viewport.
   // Then you can calculate the center point of the element by adding half of the width and height to its top-left position
@@ -54,112 +82,22 @@ export function centerOn(element: HTMLElement, options: { instance: any }) {
   const child = element
   const childRect = child.getBoundingClientRect()
 
-  /////////////
-
-  // Calculate the center point of the element
-
-  // const containerCenterX = containerRect.left + containerRect.width / 2
-  // const containerCenterY = containerRect.top + containerRect.height / 2
-  // const childCenterX = childRect.left + childRect.width / 2
-  // const childCenterY = childRect.top + childRect.height / 2
-  // const dx = containerCenterX - childCenterX
-  // const dy = containerCenterY - childCenterY
-  // const distance = Math.sqrt(dx * dx + dy * dy)
-  // const intensity = Math.min(1, distance / (containerRect.width / 2))
-  // const factorX = dx * intensity * (childRect.width / containerRect.width)
-  // const factorY = dy * intensity * (childRect.height / containerRect.height)
-  // const centerX =
-  //   (parentRect.width - childRect.width) / 2 +
-  //   containerRect.left -
-  //   childRect.left +
-  //   factorX
-  // const centerY =
-  //   (parentRect.height - childRect.height) / 2 +
-  //   containerRect.top -
-  //   childRect.top +
-  //   factorY
-
-  // console.log('Distance', distance)
-
-  ///////////////
-  // const containerWidth = container.clientWidth
-  // const containerHeight = container.clientHeight
-  // const centerX =
-  //   (parentRect.width - containerRect.width + childRect.width) / 2 -
-  //   childRect.left
-  // const centerY =
-  //   (parentRect.height - containerRect.height + childRect.height) / 2 -
-  //   childRect.top
-
-  // console.log('centerX:', centerX)
-  // console.log('centerY:', centerY)
-  ////////////
-
-  // const centerX = (parentRect.width - childRect.width) / 2 - childRect.left
-  // const centerY = (parentRect.height - childRect.height) / 2 - childRect.top
-
-  // Calculate the zoom scale
-  // const panzoomViewportRect = {
-  //   width: parent.offsetWidth,
-  //   height: parent.offsetHeight,
-  // }
-  // const zoom = zoomToFitElement(element)
-  // const zoom = options.instance.getScale()
-  // if (!zoom) return false
-
-  // TODO: Include window.devicePixelRatio?
-
-  // var viewportWidth = parentRect.width
-  // var viewportHeight = parentRect.height
-  // var childWidth = childRect.width * zoom // We want to use the rendered width
-  // var childHeight = childRect.height * zoom // We want to use the rendered height
-  // var childX = (childRect.left - parentRect.left) / zoom
-  // var childY = (childRect.top - parentRect.top) / zoom
-  // var minX = Math.max(0, childWidth / 2 - parentRect.width / 2 - childX)
-  // var minY = Math.max(0, childHeight / 2 - parentRect.height / 2 - childY)
-  // var centerX = parentRect.width / 2 - childWidth / 2 + minX
-  // var centerY = parentRect.height / 2 - childHeight / 2 + minY
-
-  // const centerX = parentRect.left + parentRect.width / 2
-  // const centerY = parentRect.top + parentRect.height / 2
-
-  // const offsetX =
-  //   centerX -
-  //   (childRect.left + childRect.width / 2) -
-  //   (childRect.width - parentRect.width) / 2
-  // const offsetY =
-  //   centerY -
-  //   (childRect.top + childRect.height / 2) -
-  //   (childRect.height - parentRect.height) / 2
-
-  // // const centerXOnScreen = window.innerWidth / 2 - parentRect.left - parentRect.width / 2 + offsetX;
-  // // const centerYOnScreen = window.innerHeight / 2 - parentRect.top - parentRect.height / 2 + offsetY;
-
-  // console.log(parent, element.closest(panzoomChild), element) // Elements
-  // console.log(zoom, centerX, centerY, { child, container }) // Output
-  // options.instance.pan(offsetX, offsetY)
-
-  ////////////////////////////////
-
-  console.log('Test', {
-    parent: parent,
-    container: container,
-    child: child,
-  })
+  // console.log('Test', {
+  //   parent: parent,
+  //   container: container,
+  //   child: child,
+  // })
 
   // Current settings
+  // TODO: Get the current zoom level
   const zoom = options.instance.getScale()
+  console.log('Zoom', zoom)
   if (!zoom) return false
 
   // Get the viewport dimensions in pixels
   const viewportWidth = parent.offsetWidth
   const viewportHeight = parent.offsetHeight
-  // const viewportWidth = parentRect.width
-  // const viewportHeight = parentRect.height
 
-  // Get the offset from the container element
-  // const containerOffsetLeft = childRect.left
-  // const containerOffsetTop = childRect.top
   const containerOffsetLeft = child.offsetLeft * zoom
   const containerOffsetTop = child.offsetTop * zoom
   console.log('offset', containerOffsetLeft, containerOffsetTop)
@@ -171,8 +109,6 @@ export function centerOn(element: HTMLElement, options: { instance: any }) {
 
   // Calculate the center point of the viewport, adjusted for the container offset
   // Factor in the zoom level
-  // const viewportCenterX = viewportWidth / 2 - containerOffsetLeft
-  // const viewportCenterY = viewportHeight / 2 - containerOffsetTop
   const viewportCenterX = (viewportWidth / 2 - containerOffsetLeft) / zoom
   const viewportCenterY = (viewportHeight / 2 - containerOffsetTop) / zoom
 
@@ -180,12 +116,8 @@ export function centerOn(element: HTMLElement, options: { instance: any }) {
   console.log('viewportCenterY:', viewportCenterY)
 
   // Set the position of the element to the adjusted center point of the viewport
-  // const elementWidth = childRect.width
-  // const elementHeight = childRect.height
   const elementWidth = child.offsetWidth
   const elementHeight = child.offsetHeight
-  // const elementWidth = parseFloat(getComputedStyle(element).width)
-  // const elementHeight = parseFloat(getComputedStyle(element).height)
 
   console.log('elementWidth:', elementWidth)
   console.log('elementHeight:', elementHeight)
@@ -200,17 +132,17 @@ export function centerOn(element: HTMLElement, options: { instance: any }) {
   // Normally, we pan relative to the container
   // But we want to pan relative to a specific element, so we can
   // set our own transform values to be more specific
-  // options.instance.setTransform()
-  options.instance.setStyle(
-    'transform',
-    `scale(${zoom}) translate(${x}px, ${y}px)`
+
+  options.instance.zoom(zoom)
+  setTimeout(() =>
+    options.instance.setStyle(
+      'transform',
+      `scale(${zoom}) translate(${x}px, ${y}px)`
+    )
   )
-  console.log()
 
   // options.instance.pan(x, y)
   ////////////////////////////////
-
-  // options.instance.zoom(zoom)
 
   // Firstly calculate the offset of the element relative to the parent
   // The first artboard is always 0,0
@@ -296,22 +228,158 @@ export function centerOn(element: HTMLElement, options: { instance: any }) {
   // options.instance.pan(panX, panY)
   // options.instance.zoom(zoom)
 }
+
+/**
+ * Get the XY coordinates of the center of the viewport
+ */
+export function getCenterCoordinates(
+  element: HTMLElement,
+  zoom: number,
+  options?: { instance: PanzoomObject }
+) {
+  let scale
+
+  // Set zoom
+  scale = zoom ? zoom : options?.instance.getScale()
+
+  console.log('scale', scale)
+
+  const { el: parent, rect: parentRect } = getPanzoomElement('viewport')
+  const { el: container, rect: containerRect } = getPanzoomElement('container')
+  const child = element
+
+  // Get the viewport dimensions in pixels
+  const viewportWidth = parent.offsetWidth
+  const viewportHeight = parent.offsetHeight
+  console.log(viewportHeight, viewportWidth)
+
+  // Get the offset from the container element
+  const containerOffsetLeft = child.offsetLeft * scale
+  const containerOffsetTop = child.offsetTop * scale
+  console.log('offset', containerOffsetLeft, containerOffsetTop)
+
+  console.log('viewportWidth:', viewportWidth)
+  console.log('viewportHeight:', viewportHeight)
+  console.log('containerOffsetLeft:', containerOffsetLeft)
+  console.log('containerOffsetTop:', containerOffsetTop)
+
+  // Calculate the center point of the viewport, adjusted for the container offset
+  // Factor in the zoom level
+  const viewportCenterX = (viewportWidth / 2 - containerOffsetLeft) / scale
+  const viewportCenterY = (viewportHeight / 2 - containerOffsetTop) / scale
+
+  console.log('viewportCenterX:', viewportCenterX)
+  console.log('viewportCenterY:', viewportCenterY)
+
+  // Set the position of the element to the adjusted center point of the viewport
+  const elementWidth = child.offsetWidth
+  const elementHeight = child.offsetHeight
+
+  console.log('elementWidth:', elementWidth)
+  console.log('elementHeight:', elementHeight)
+
+  // Final position
+  const x = viewportCenterX - elementWidth / 2
+  const y = viewportCenterY - elementHeight / 2
+
+  console.log('x:', x)
+  console.log('y:', y)
+
+  return { x, y }
+}
+
+/**
+ * Returns the X, Y coordinates of an element
+ * relative to the inner Panzoom container.
+ * Can use these coordinates with panzoom.pan()
+ */
+function getElementCoordinates(e: HTMLElement, zoom: number) {
+  // The Panzoom viewport node
+  // The Panzoom content container node
+  // Some specific element node _within_ the Panzoon content container
+
+  // 1. Calculate the center of the viewport element and the container element
+  // 2. Calculate the offset of a specific element relative to the container element
+  // 3. Calculate final x,y coordinates which will put the specific element in the center of the viewport
+  // given that center is calculated relative to the container element
+
+  const viewport = document.querySelector<HTMLElement>(panzoomContainer)
+  const container = document.querySelector(panzoomChild) as HTMLElement
+  const element = e
+
+  const viewportCenterX = viewport.clientWidth / 2 + viewport.scrollLeft
+  const viewportCenterY = viewport.clientHeight / 2 + viewport.scrollTop
+
+  const containerRect = container.getBoundingClientRect()
+  const containerCenterX = containerRect.left + containerRect.width / 2
+  const containerCenterY = containerRect.top + containerRect.height / 2
+
+  const elementRect = element.getBoundingClientRect()
+
+  const elementOffsetX = elementRect.left - containerRect.left
+  const elementOffsetY = elementRect.top - containerRect.top
+
+  const finalX = viewportCenterX - (elementOffsetX + elementRect.width / 2)
+  const finalY = viewportCenterY - (elementOffsetY + elementRect.height / 2)
+
+  return {
+    x: finalX,
+    y: finalY,
+  }
+}
+
+function zoomToFitElement(e: HTMLElement) {
+  // 1. Calculate the dimensions of the element and the viewport
+  // 2. Calculate the scaling factor based on the dimensions of the element and the viewport
+  // 3. Set the zoom level of the container element to the calculated scale factor
+  const viewport = document.querySelector<HTMLElement>(panzoomChild)
+  const elementRect = e.getBoundingClientRect()
+
+  if (!viewport || !elementRect) {
+    console.error('Failed to get element')
+    return false
+  }
+
+  const viewportWidth = viewport.offsetWidth
+  const viewportHeight = viewport.offsetHeight
+
+  const elementWidth = elementRect.width
+  const elementHeight = elementRect.height
+
+  const zoomPadding = 0.9 // add extra space on sides of the content
+  const zoomX =
+    (viewportWidth / (elementRect.left + elementWidth)) * zoomPadding
+  const zoomY =
+    (viewportHeight / (elementRect.top + elementHeight)) * zoomPadding
+
+  const scaleFactor = Math.min(zoomX, zoomY)
+
+  console.log('Zooom', scaleFactor, viewport, e)
+
+  return scaleFactor
+}
+
 /**
  * Returns a zoom factor which would fit all the current artboards within the viewport
  */
 export function calculateZoomToFitAll(): number {
-  const panzoomEl = document.querySelector<HTMLElement>(panzoomContainer)
-  if (!panzoomEl) {
+  const { el: viewport } = getPanzoomElement('viewport')
+  if (!viewport) {
     console.error('No container')
     return 1
   }
-  const childElement = panzoomEl?.querySelector(panzoomChild) as HTMLElement
+
+  const { el: container } = getPanzoomElement('container')
+  if (!container) {
+    console.error('No container')
+    return 1
+  }
 
   const panzoomViewportRect = {
-    width: panzoomEl.offsetWidth,
-    height: panzoomEl.offsetHeight,
+    width: viewport.offsetWidth,
+    height: viewport.offsetHeight,
   }
-  const childRect = childElement.getBoundingClientRect()
+  const childRect = container.getBoundingClientRect()
   const childWidth = childRect.width
   const childHeight = childRect.height
 
@@ -319,9 +387,8 @@ export function calculateZoomToFitAll(): number {
   const zoomPadding = 0.9 // add extra space on sides of the content
   const zoomX = (panzoomViewportRect.width / childWidth) * zoomPadding
   const zoomY = (panzoomViewportRect.height / childHeight) * zoomPadding
-  const zoom = Math.min(zoomX, zoomY)
+  let zoom = Math.min(zoomX, zoomY)
 
   // Return
   return zoom
 }
-

--- a/app/src/renderer/components/panzoom/panzoomFns.ts
+++ b/app/src/renderer/components/panzoom/panzoomFns.ts
@@ -1,0 +1,36 @@
+export function initialPan() {
+  const panzoomEl = document.querySelector<HTMLElement>('.panzoom-container')
+  if (!panzoomEl) {
+    console.error('No container')
+    return {}
+  }
+  const childElement = panzoomEl?.querySelector('.panzoom-inner') as HTMLElement
+
+  const panzoomRect = panzoomEl.getBoundingClientRect()
+  const childRect = childElement.getBoundingClientRect()
+
+  const panzoomViewportRect = {
+    width: panzoomEl.offsetWidth,
+    height: panzoomEl.offsetHeight,
+  }
+  const childWidth = childRect.width
+  const childHeight = childRect.height
+
+  // Calculate the zoom scale
+  const zoomPadding = 0.9 // add extra space on sides of the content
+  const zoomX = (panzoomViewportRect.width / childWidth) * zoomPadding
+  const zoomY = (panzoomViewportRect.height / childHeight) * zoomPadding
+  const zoom = Math.min(zoomX, zoomY)
+
+  // Pan
+  const panX = (panzoomRect.width - childRect.width) / 2 - childRect.left
+  const panY = (panzoomRect.height - childRect.height) / 2 - childRect.top
+
+  // center child element within viewport
+  return {
+    x: panX,
+    y: panY,
+    zoom: zoom,
+  }
+}
+

--- a/app/src/renderer/components/panzoom/panzoomFns.ts
+++ b/app/src/renderer/components/panzoom/panzoomFns.ts
@@ -1,26 +1,24 @@
-export function initialPan() {
-  const panzoomEl = document.querySelector<HTMLElement>('.panzoom-container')
+// The CSS classes
+// TODO: Add tests to make sure these don't break
+const panzoomContainer = '.panzoom-container'
+const panzoomChild = '.panzoom-inner'
+
+/**
+ * Returns the x, y, zoom for the initial app startup
+ */
+export function initialPanZoom() {
+  const panzoomEl = document.querySelector<HTMLElement>(panzoomContainer)
   if (!panzoomEl) {
     console.error('No container')
     return {}
   }
-  const childElement = panzoomEl?.querySelector('.panzoom-inner') as HTMLElement
+  const childElement = panzoomEl?.querySelector(panzoomChild) as HTMLElement
 
   const panzoomRect = panzoomEl.getBoundingClientRect()
   const childRect = childElement.getBoundingClientRect()
 
-  const panzoomViewportRect = {
-    width: panzoomEl.offsetWidth,
-    height: panzoomEl.offsetHeight,
-  }
-  const childWidth = childRect.width
-  const childHeight = childRect.height
-
-  // Calculate the zoom scale
-  const zoomPadding = 0.9 // add extra space on sides of the content
-  const zoomX = (panzoomViewportRect.width / childWidth) * zoomPadding
-  const zoomY = (panzoomViewportRect.height / childHeight) * zoomPadding
-  const zoom = Math.min(zoomX, zoomY)
+  // Calculate the zoom to fit all artboards
+  const zoom = calculateZoomToFitAll()
 
   // Pan
   const panX = (panzoomRect.width - childRect.width) / 2 - childRect.left
@@ -32,5 +30,33 @@ export function initialPan() {
     y: panY,
     zoom: zoom,
   }
+}
+/**
+ * Returns a zoom factor which would fit all the current artboards within the viewport
+ */
+export function calculateZoomToFitAll(): number {
+  const panzoomEl = document.querySelector<HTMLElement>(panzoomContainer)
+  if (!panzoomEl) {
+    console.error('No container')
+    return 1
+  }
+  const childElement = panzoomEl?.querySelector(panzoomChild) as HTMLElement
+
+  const panzoomViewportRect = {
+    width: panzoomEl.offsetWidth,
+    height: panzoomEl.offsetHeight,
+  }
+  const childRect = childElement.getBoundingClientRect()
+  const childWidth = childRect.width
+  const childHeight = childRect.height
+
+  // Calculate the zoom scale
+  const zoomPadding = 0.9 // add extra space on sides of the content
+  const zoomX = (panzoomViewportRect.width / childWidth) * zoomPadding
+  const zoomY = (panzoomViewportRect.height / childHeight) * zoomPadding
+  const zoom = Math.min(zoomX, zoomY)
+
+  // Return
+  return zoom
 }
 

--- a/app/src/renderer/components/panzoom/panzoomFns.ts
+++ b/app/src/renderer/components/panzoom/panzoomFns.ts
@@ -5,6 +5,7 @@ import Panzoom, { PanzoomObject } from '@panzoom/panzoom'
 // TODO: Add tests to make sure these don't break
 const panzoomContainer = '.panzoom-container'
 const panzoomChild = '.panzoom-inner'
+const zoomPadding = 0.25
 
 function getPanzoomElement(name: 'viewport' | 'container') {
   const viewport = document.querySelector(panzoomContainer) as HTMLElement
@@ -42,14 +43,12 @@ function getPanzoomElement(name: 'viewport' | 'container') {
  * Returns the x, y, zoom for the initial app startup
  */
 export function initialPanZoom() {
-  const { el: parent } = getPanzoomElement('viewport')
-  const childElement = parent?.querySelector(panzoomChild) as HTMLElement
-
   // Calculate the zoom to fit all artboards
   const zoom = calculateZoomToFitAll()
 
   // Pan
-  const { x: panX, y: panY } = getCenterCoordinates(childElement, zoom)
+  // Old calculation: https://github.com/reflex-app/reflex/blob/42b07e33cbed8404d60749c29f0ed5f04a412184/app/src/renderer/components/panzoom/panzoomFns.ts#L23
+  const { x: panX, y: panY } = getViewportCenterCoordinates(zoom)
 
   // center child element within viewport
   return {
@@ -59,24 +58,27 @@ export function initialPanZoom() {
   }
 }
 
-export function centerOn(element: HTMLElement, options: { instance: any }) {
+/**
+ * Programmatically centers an element in the viewport
+ */
+export function centerOnElement(
+  element: HTMLElement,
+  options: { instance: any }
+) {
   // Get the position and dimensions of the element relative to the viewport.
   // Then you can calculate the center point of the element by adding half of the width and height to its top-left position
   // Then subtract the position of the parent element to get the center relative to its parent.
-  // const parent = document.querySelector<HTMLElement>(panzoomContainer)
-  const parent = document.querySelector<HTMLElement>(panzoomContainer)
-  // const parent = document.documentElement
+
+  const { el: parent, rect: parentRect } = getPanzoomElement('viewport')
   if (!parent) {
     console.error('No container')
     return {}
   }
   // Calculate the position of the element relative to the parent container
-  const parentRect = parent.getBoundingClientRect()
 
   // Get the full size of the artboards container (panzoomChild)
-  const container = element.closest(panzoomChild) as HTMLElement
+  const { el: container, rect: containerRect } = getPanzoomElement('container')
   if (!container) return false
-  const containerRect = container.getBoundingClientRect()
 
   // Get the element's bounding rectangle relative to the viewport
   const child = element
@@ -90,7 +92,8 @@ export function centerOn(element: HTMLElement, options: { instance: any }) {
 
   // Current settings
   // TODO: Get the current zoom level
-  const zoom = options.instance.getScale()
+  // const zoom = options.instance.getScale()
+  const zoom = getZoomToFitElement(child)
   console.log('Zoom', zoom)
   if (!zoom) return false
 
@@ -132,108 +135,21 @@ export function centerOn(element: HTMLElement, options: { instance: any }) {
   // Normally, we pan relative to the container
   // But we want to pan relative to a specific element, so we can
   // set our own transform values to be more specific
+  // This works... but it would be better to use pan() and zoom()
+  // options.instance.setStyle(
+  //   'transform',
+  //   `scale(${zoom}) translate(${x}px, ${y}px)`
+  // )
 
+  // Perform the panning & zoom
+  options.instance.pan(x, y)
   options.instance.zoom(zoom)
-  setTimeout(() =>
-    options.instance.setStyle(
-      'transform',
-      `scale(${zoom}) translate(${x}px, ${y}px)`
-    )
-  )
-
-  // options.instance.pan(x, y)
-  ////////////////////////////////
-
-  // Firstly calculate the offset of the element relative to the parent
-  // The first artboard is always 0,0
-  // NOTE: other elements are always negative, because the elements are on the right. Positive values are on the left.
-  // Then, subtract the width and height of the element (including padding, border, and margin)
-  // NOTE: Use .getBoundingClientRect() to because it returns the rendered size of the element (incl. CSS transforms)
-  // Use .offsetLeft/offsetTop to get position which Panzoom uses
-  // Finally, we get the difference of the parent and container width/height
-
-  // const elWidth = child.offsetWidth / 2
-  // const elHeight = child.offsetHeight / 2
-  // // const elWidth = childRect.width / 2
-  // // const elHeight = childRect.height / 2
-  // console.log(elWidth)
-
-  // const arbitraryX =
-
-  // // const parentDiff = container.offsetLeft - parent.offsetLeft
-  // const parentDiff = containerRect.left - parentRect.left
-  // // const parentDiff = containerRect.left
-  // // const parentDiff = containerRect.left
-  // console.log(parentDiff)
-
-  // let negativeX, negativeY
-  // child.offsetLeft === 0 ? (negativeX = false) : (negativeX = true)
-  // child.offsetTop === 0 ? (negativeY = false) : (negativeY = true)
-
-  // let newX, newY
-  // newX = child.offsetLeft + elWidth
-  // newY = child.offsetTop - elHeight
-
-  // if (negativeX) {
-  //   console.log('Negative X')
-  //   newX = -newX
-  // }
-  // if (negativeY) {
-  //   console.log('Negative Y')
-  //   newX = -newY
-  // }
-
-  // console.log(newX, newY, { element, container, parent })
-  // options.instance.pan(newX, newY)
-  // options.instance.pan(newX, newY)
-  // setTimeout(() => options.instance.zoom(zoom))
-
-  // options.instance.zoom(zoom)
-
-  // options.instance.zoomToPoint(zoom, {
-  //   clientX: centerX,
-  //   clientY: centerY,
-  // })
-
-  // const panzoomEl = document.querySelector<HTMLElement>(panzoomContainer)
-  // if (!panzoomEl) {
-  //   console.error('No container')
-  //   return {}
-  // }
-  // // const childElement = panzoomEl?.querySelector(panzoomChild) as HTMLElement
-  // const childElement = element.closest(panzoomChild) as HTMLElement
-  // console.log(childElement)
-
-  // const panzoomRect = panzoomEl.getBoundingClientRect()
-  // const childRect = childElement.getBoundingClientRect()
-
-  // const panzoomViewportRect = {
-  //   width: panzoomEl.offsetWidth,
-  //   height: panzoomEl.offsetHeight,
-  // }
-  // const childWidth = childRect.width
-  // const childHeight = childRect.height
-
-  // // Calculate the zoom scale
-  // const zoomPadding = 0.9 // add extra space on sides of the content
-  // const zoomX = (panzoomViewportRect.width / childWidth) * zoomPadding
-  // const zoomY = (panzoomViewportRect.height / childHeight) * zoomPadding
-  // const zoom = Math.min(zoomX, zoomY)
-
-  // // Pan
-  // const panX = (panzoomRect.width - childRect.width) / 2 - childRect.left
-  // const panY = (panzoomRect.height - childRect.height) / 2 - childRect.top
-
-  // // center child element within viewport
-  // options.instance.pan(panX, panY)
-  // options.instance.zoom(zoom)
 }
 
 /**
- * Get the XY coordinates of the center of the viewport
+ * This will get coordinates to place the container at the top-left of the viewport
  */
-export function getCenterCoordinates(
-  element: HTMLElement,
+export function getCoordinatesTopLeft(
   zoom: number,
   options?: { instance: PanzoomObject }
 ) {
@@ -244,48 +160,83 @@ export function getCenterCoordinates(
 
   console.log('scale', scale)
 
-  const { el: parent, rect: parentRect } = getPanzoomElement('viewport')
+  const { el: viewport, rect: viewportRect } = getPanzoomElement('viewport')
   const { el: container, rect: containerRect } = getPanzoomElement('container')
-  const child = element
+
+  if (!viewport || !container) return {}
 
   // Get the viewport dimensions in pixels
-  const viewportWidth = parent.offsetWidth
-  const viewportHeight = parent.offsetHeight
+  const viewportWidth = viewport.offsetWidth
+  const viewportHeight = viewport.offsetHeight
   console.log(viewportHeight, viewportWidth)
 
   // Get the offset from the container element
-  const containerOffsetLeft = child.offsetLeft * scale
-  const containerOffsetTop = child.offsetTop * scale
-  console.log('offset', containerOffsetLeft, containerOffsetTop)
-
-  console.log('viewportWidth:', viewportWidth)
-  console.log('viewportHeight:', viewportHeight)
-  console.log('containerOffsetLeft:', containerOffsetLeft)
-  console.log('containerOffsetTop:', containerOffsetTop)
+  const containerOffsetLeft = container.offsetLeft * scale
+  const containerOffsetTop = container.offsetTop * scale
 
   // Calculate the center point of the viewport, adjusted for the container offset
   // Factor in the zoom level
-  const viewportCenterX = (viewportWidth / 2 - containerOffsetLeft) / scale
-  const viewportCenterY = (viewportHeight / 2 - containerOffsetTop) / scale
-
-  console.log('viewportCenterX:', viewportCenterX)
-  console.log('viewportCenterY:', viewportCenterY)
-
-  // Set the position of the element to the adjusted center point of the viewport
-  const elementWidth = child.offsetWidth
-  const elementHeight = child.offsetHeight
-
-  console.log('elementWidth:', elementWidth)
-  console.log('elementHeight:', elementHeight)
+  const viewportCenterX = viewportWidth / 2 - containerOffsetLeft
+  const viewportCenterY = viewportHeight / 2 - containerOffsetTop
 
   // Final position
-  const x = viewportCenterX - elementWidth / 2
-  const y = viewportCenterY - elementHeight / 2
+  const containerWidth = Math.min(container.offsetWidth, viewportWidth)
+  const containerHeight = Math.min(container.offsetHeight, viewportHeight)
+  const x = viewportCenterX - containerWidth / 2
+  const y = viewportCenterY - containerHeight / 2
+
+  const offsetX = (viewportWidth - containerWidth) / 2
+  const offsetY = (viewportHeight - containerHeight) / 2
+
+  const finalX = x + offsetX
+  const finalY = y + offsetY
 
   console.log('x:', x)
   console.log('y:', y)
 
-  return { x, y }
+  return { x: finalX, y: finalY }
+}
+
+/**
+ * Get the XY coordinates at the center of the viewport(container)
+ * Useful for centering all artboards in the viewport
+ */
+export function getViewportCenterCoordinates(
+  zoom: number,
+  options?: { instance: PanzoomObject }
+) {
+  let scale
+
+  // Set zoom
+  scale = zoom ? zoom : options?.instance.getScale()
+
+  const { el: viewport } = getPanzoomElement('viewport')
+  const { el: container } = getPanzoomElement('container')
+
+  if (!viewport || !container) return {}
+
+  // Get the viewport dimensions in pixels
+  const viewportWidth = viewport.offsetWidth
+  const viewportHeight = viewport.offsetHeight
+
+  // Get the offset from the container element
+  const containerOffsetLeft = container.offsetLeft * scale
+  const containerOffsetTop = container.offsetTop * scale
+
+  // Calculate the center point of the viewport, adjusted for the container offset
+  const viewportCenterX = (viewportWidth / 2 + containerOffsetLeft) / scale
+  const viewportCenterY = (viewportHeight / 2 + containerOffsetTop) / scale
+
+  // Calculate the container dimensions, scaled to the current zoom level
+  // NOTE: We don't need to calculate scale here
+  const containerWidth = container.offsetWidth
+  const containerHeight = container.offsetHeight
+
+  // Calculate the position of the container to be centered on the viewport center point
+  const x = viewportCenterX - containerWidth / 2
+  const y = viewportCenterY - containerHeight / 2
+
+  return { x: x, y: y }
 }
 
 /**
@@ -293,70 +244,97 @@ export function getCenterCoordinates(
  * relative to the inner Panzoom container.
  * Can use these coordinates with panzoom.pan()
  */
-function getElementCoordinates(e: HTMLElement, zoom: number) {
-  // The Panzoom viewport node
-  // The Panzoom content container node
-  // Some specific element node _within_ the Panzoon content container
+function getElementCoordinates(e: HTMLElement, zoom: number, options) {
+  let scale
 
-  // 1. Calculate the center of the viewport element and the container element
-  // 2. Calculate the offset of a specific element relative to the container element
-  // 3. Calculate final x,y coordinates which will put the specific element in the center of the viewport
-  // given that center is calculated relative to the container element
+  // Set zoom
+  scale = zoom ? zoom : options?.instance.getScale()
 
-  const viewport = document.querySelector<HTMLElement>(panzoomContainer)
-  const container = document.querySelector(panzoomChild) as HTMLElement
-  const element = e
+  console.log('scale', scale)
 
-  const viewportCenterX = viewport.clientWidth / 2 + viewport.scrollLeft
-  const viewportCenterY = viewport.clientHeight / 2 + viewport.scrollTop
+  const { el: viewport, rect: viewportRect } = getPanzoomElement('viewport')
+  const { el: container, rect: containerRect } = getPanzoomElement('container')
+  const child = e
 
-  const containerRect = container.getBoundingClientRect()
-  const containerCenterX = containerRect.left + containerRect.width / 2
-  const containerCenterY = containerRect.top + containerRect.height / 2
+  if (!viewport || !container) {
+    console.error('No parent or container element found')
+    return { x: 0, y: 0 }
+  }
 
-  const elementRect = element.getBoundingClientRect()
+  const containerOffsetLeft = containerRect.left - viewport.offsetLeft
+  const containerOffsetTop = containerRect.top - viewport.offsetTop
 
-  const elementOffsetX = elementRect.left - containerRect.left
-  const elementOffsetY = elementRect.top - containerRect.top
+  // Calculate the center coordinates of the "container" element, accounting for the zoom/scale factor
+  const containerCenterX =
+    (containerOffsetLeft + container.offsetWidth / 2) * scale
+  const containerCenterY =
+    (containerOffsetTop + container.offsetHeight / 2) * scale
 
-  const finalX = viewportCenterX - (elementOffsetX + elementRect.width / 2)
-  const finalY = viewportCenterY - (elementOffsetY + elementRect.height / 2)
+  // Calculate the center coordinates of the "child" element relative to the "container" element, accounting for the zoom/scale factor
+  const childCenterX = (child.offsetWidth / 2) * scale
+  const childCenterY = (child.offsetHeight / 2) * scale
+
+  // Calculate the final center coordinates of the "child" element, accounting for the relative positioning and zoom/scale factor
+  const finalCenterX = containerCenterX + childCenterX
+  const finalCenterY = containerCenterY + childCenterY
 
   return {
-    x: finalX,
-    y: finalY,
+    x: finalCenterX,
+    y: finalCenterY,
   }
 }
 
-function zoomToFitElement(e: HTMLElement) {
-  // 1. Calculate the dimensions of the element and the viewport
-  // 2. Calculate the scaling factor based on the dimensions of the element and the viewport
-  // 3. Set the zoom level of the container element to the calculated scale factor
-  const viewport = document.querySelector<HTMLElement>(panzoomChild)
-  const elementRect = e.getBoundingClientRect()
-
-  if (!viewport || !elementRect) {
-    console.error('Failed to get element')
-    return false
+/**
+ * Returns the zoom scale needed to fit a specific element (e.g. an <Artboard>) in the viewport
+ */
+function getZoomToFitElement(e: HTMLElement) {
+  const { el: viewport } = getPanzoomElement('viewport')
+  if (!viewport) {
+    console.error('No container')
+    return 1
   }
 
-  const viewportWidth = viewport.offsetWidth
-  const viewportHeight = viewport.offsetHeight
+  const { el: container, rect: containerRect } = getPanzoomElement('container')
+  if (!container) {
+    console.error('No container')
+    return 1
+  }
 
-  const elementWidth = elementRect.width
-  const elementHeight = elementRect.height
+  const child = e
 
-  const zoomPadding = 0.9 // add extra space on sides of the content
-  const zoomX =
-    (viewportWidth / (elementRect.left + elementWidth)) * zoomPadding
-  const zoomY =
-    (viewportHeight / (elementRect.top + elementHeight)) * zoomPadding
+  // Calculate the zoom scale based on the longer side of the child element
+  const widthRatio =
+    viewport.offsetWidth / (child.offsetWidth + child.offsetWidth * zoomPadding)
+  const heightRatio =
+    viewport.offsetHeight /
+    (child.offsetHeight + child.offsetHeight * zoomPadding)
 
-  const scaleFactor = Math.min(zoomX, zoomY)
+  // If the child height is greater than the viewport height, calculate the zoom scale based on the child height
+  const maxHeightRatio =
+    viewport.offsetHeight /
+    (child.offsetHeight +
+      child.offsetHeight *
+        zoomPadding *
+        (viewport.offsetWidth / child.offsetWidth))
+  const aspectRatio = child.offsetWidth / child.offsetHeight
+  const maxAdjustedHeightRatio =
+    viewport.offsetHeight /
+    (child.offsetHeight +
+      (child.offsetHeight *
+        zoomPadding *
+        Math.sqrt(viewport.offsetWidth / child.offsetWidth)) /
+        aspectRatio)
 
-  console.log('Zooom', scaleFactor, viewport, e)
+  // Adjust the zoom ratio based on the aspect ratio of the child element
+  const zoom = Math.min(
+    widthRatio,
+    heightRatio,
+    maxHeightRatio / aspectRatio,
+    maxAdjustedHeightRatio
+  )
 
-  return scaleFactor
+  // Return
+  return zoom
 }
 
 /**
@@ -369,26 +347,42 @@ export function calculateZoomToFitAll(): number {
     return 1
   }
 
-  const { el: container } = getPanzoomElement('container')
+  const { el: container, rect: containerRect } = getPanzoomElement('container')
   if (!container) {
     console.error('No container')
     return 1
   }
 
-  const panzoomViewportRect = {
-    width: viewport.offsetWidth,
-    height: viewport.offsetHeight,
-  }
-  const childRect = container.getBoundingClientRect()
-  const childWidth = childRect.width
-  const childHeight = childRect.height
+  // Calculate the zoom scale based on the longer side of the child element
+  const widthRatio =
+    viewport.offsetWidth /
+    (container.offsetWidth + container.offsetWidth * zoomPadding)
+  const heightRatio =
+    viewport.offsetHeight /
+    (container.offsetHeight + container.offsetHeight * zoomPadding)
 
-  // Calculate the zoom scale
-  const zoomPadding = 0.9 // add extra space on sides of the content
-  const zoomX = (panzoomViewportRect.width / childWidth) * zoomPadding
-  const zoomY = (panzoomViewportRect.height / childHeight) * zoomPadding
-  let zoom = Math.min(zoomX, zoomY)
+  // If the container height is greater than the viewport height, calculate the zoom scale based on the container height
+  const maxHeightRatio =
+    viewport.offsetHeight /
+    (container.offsetHeight +
+      container.offsetHeight *
+        zoomPadding *
+        (viewport.offsetWidth / container.offsetWidth))
+  const aspectRatio = container.offsetWidth / container.offsetHeight
+  const maxAdjustedHeightRatio =
+    viewport.offsetHeight /
+    (container.offsetHeight +
+      (container.offsetHeight *
+        zoomPadding *
+        Math.sqrt(viewport.offsetWidth / container.offsetWidth)) /
+        aspectRatio)
 
-  // Return
+  // Adjust the zoom ratio based on the aspect ratio of the container element
+  const zoom = Math.min(
+    widthRatio,
+    heightRatio,
+    maxHeightRatio / aspectRatio,
+    maxAdjustedHeightRatio
+  )
   return zoom
 }

--- a/app/src/renderer/layouts/default.vue
+++ b/app/src/renderer/layouts/default.vue
@@ -1,43 +1,38 @@
 <template>
   <div class="container">
-    <ToolBar />
     <nuxt />
   </div>
 </template>
 
-<script>
+<script setup lang="ts">
 import { ipcRenderer } from 'electron' // TODO Migrate to @electron/remote
 import isElectron from 'is-electron'
-import ToolBar from '@/components/ToolBar'
+
 import remote from '@electron/remote'
+import { onMounted, computed, ref } from 'vue'
 
-export default {
-  components: {
-    ToolBar,
-  },
-  mounted() {
-    // TODO: get app version
-    // console.info(`Version: ${remote.app.getVersion()}`)
+onMounted(() => {
+  // TODO: get app version
+  // console.info(`Version: ${remote.app.getVersion()}`)
 
-    // Global listeners
-    if (isElectron()) {
-      ipcRenderer.on('menu_reset-app', () => {
-        if (
-          confirm(
-            `Are you sure you want to reset all data and settings? Click "OK" to reset.`
-          )
-        ) {
-          window.localStorage.clear()
+  // Global listeners
+  if (isElectron()) {
+    ipcRenderer.on('menu_reset-app', () => {
+      if (
+        confirm(
+          `Are you sure you want to reset all data and settings? Click "OK" to reset.`
+        )
+      ) {
+        window.localStorage.clear()
 
-          setTimeout(() => {
-            // TODO: replace this with IPC
-            remote.getCurrentWindow().reload()
-          }, 150)
-        }
-      })
-    }
-  },
-}
+        setTimeout(() => {
+          // TODO: replace this with IPC
+          remote.getCurrentWindow().reload()
+        }, 150)
+      }
+    })
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/app/src/renderer/pages/index.vue
+++ b/app/src/renderer/pages/index.vue
@@ -1,9 +1,15 @@
 <template>
   <div id="main-view">
+    <ToolBar ref="toolbarElement" />
     <DevModeHud />
     <SidePanel />
     <Screenshots />
     <Panzoom>
+      <!-- :style="{
+        // height: `calc(100% - ${toolbarHeight}px)`,
+        height: '100%',
+        width: '100%',
+      }" -->
       <Artboards />
     </Panzoom>
   </div>
@@ -17,11 +23,16 @@ import Screenshots from '@/components/Screenshot/index.vue'
 import Artboards from '@/components/Screens/Artboards.vue'
 import useEventHandler from '@/components/Screens/useEventHandler'
 import DevModeHud from '~/components/DevModeHud.vue'
+import ToolBar from '~/components/ToolBar/index.vue'
 
 const { init } = useEventHandler() // init event handling
 
+const toolbarElement = ref() // Template Ref
+const toolbarHeight = ref()
+
 onMounted(() => {
   init() // initialize
+  toolbarHeight.value = toolbarElement.value.$el.offsetHeight
 })
 </script>
 


### PR DESCRIPTION
- [x] Changed origin to 0,0
- [x] When app starts up, should center all the artboards within the viewport
- [x] Left click an artboard in the side panel -> center it in the viewport
  - [x] center it in the canvas
  - [x] zoom in
- [ ] CMD+Scroll or pinch to zoom, relative to focal point