### PR TITLE
Adds system performance monitoring in UI, warning during high load

### DIFF
--- a/app/components/PerfMonitor.vue
+++ b/app/components/PerfMonitor.vue
@@ -1,14 +1,36 @@
 <template>
   <div class="flex px-4 gap-2">
-    <div :title="`CPU usage: ${cpu}%`" class="perf-stack-container">
-      <div v-if="cpu > 20" class="perf-stack"></div>
-      <div v-if="cpu >= 50" class="perf-stack"></div>
-      <div v-if="cpu >= 80" class="perf-stack"></div>
+    <div
+      :title="`CPU usage: ${cpu}%`"
+      class="perf-stack-container"
+      :class="cpuClass"
+    >
+      <div class="perf-ticks">
+        <div class="perf-tick"></div>
+        <div class="perf-tick"></div>
+        <div class="perf-tick"></div>
+      </div>
+      <div class="needle-cover"></div>
+      <div
+        class="needle"
+        :style="{ transform: `rotate(${cpuDegrees}deg)` }"
+      ></div>
     </div>
-    <div :title="`Memory usage: ${memory}%`" class="perf-stack-container">
-      <div v-if="cpu > 20" class="perf-stack"></div>
-      <div v-else-if="cpu >= 50" class="perf-stack"></div>
-      <div v-else-if="cpu >= 80" class="perf-stack"></div>
+    <div
+      :title="`Memory usage: ${memory}%`"
+      class="perf-stack-container"
+      :class="memoryClass"
+    >
+      <div class="perf-ticks">
+        <div class="perf-tick"></div>
+        <div class="perf-tick"></div>
+        <div class="perf-tick"></div>
+      </div>
+      <div class="needle-cover"></div>
+      <div
+        class="needle"
+        :style="{ transform: `rotate(${memoryDegrees}deg)` }"
+      ></div>
     </div>
   </div>
 </template>
@@ -20,12 +42,40 @@ import { useArtboardsStore } from '@/store/artboards'
 
 const artboards = useArtboardsStore()
 
+let userAcceptedPerfWarnings: boolean | null = null
+let userAlertedAboutPerfWarnings = false
+
 const cpu = ref(0)
 const memory = ref(0)
 
+const cpuDegrees = computed(() => percentageToDegrees(cpu.value))
+const memoryDegrees = computed(() => percentageToDegrees(memory.value))
+
+const cpuClass = computed(() => {
+  return colorLogic(cpu.value)
+})
+
+const memoryClass = computed(() => {
+  return colorLogic(memory.value)
+})
+
+const colorLogic = (val: number) => {
+  if (val < 40) {
+    return 'bg-green'
+  } else if (val < 70) {
+    return 'bg-yellow'
+  } else {
+    return 'bg-red'
+  }
+}
+
 onMounted(() => {
   if (isElectron()) {
-    ipcRenderer.on('perf-warning', perfHandler)
+    ipcRenderer.on('perf-warning', (event, message) => {
+      if (!userAlertedAboutPerfWarnings) {
+        perfHandler(event, message)
+      }
+    })
 
     ipcRenderer.on('perf-cpu', (e, value) => perfStreamHandler('cpu', value))
 
@@ -35,8 +85,6 @@ onMounted(() => {
   }
 })
 
-let userAcceptedPerfWarnings: boolean | null = null
-
 function perfStreamHandler(type: 'cpu' | 'memory', value: number) {
   if (type === 'cpu') {
     cpu.value = value
@@ -45,15 +93,33 @@ function perfStreamHandler(type: 'cpu' | 'memory', value: number) {
   }
 }
 
+function percentageToDegrees(percentage: number): number {
+  if (percentage < 0 || percentage > 100) {
+    throw new Error('Percentage must be between 0 and 100')
+  }
+
+  // Convert the percentage to degrees, for a semi-circle.
+  // Also, offset by -90 degrees so 0% is left, 50% is up, and 100% is right.
+  let degrees = (percentage - 50) * 1.8
+
+  return degrees
+}
+
 /**
  * Helper to disable WebViews when system performance may be affected
  */
 function perfHandler(event: Event, message?: string) {
   if (userAcceptedPerfWarnings === null) {
+    userAlertedAboutPerfWarnings = true
+
     // Immediately hide all webviews
     hideWebViews()
 
-    if (confirm(`Performance warning! ${message} Continue anyway?`)) {
+    if (
+      confirm(
+        `Performance warning! ${message} Continue anyway? Click "OK" to continue, or "Cancel" to hide all screens.`
+      )
+    ) {
       userAcceptedPerfWarnings = true
       showWebViews()
     } else {
@@ -66,6 +132,11 @@ function perfHandler(event: Event, message?: string) {
 
       // 2. Re-enable WebViews
       showWebViews()
+
+      // 3. Inform user what happened
+      alert(
+        'We have set all screen sizes to hidden so that performance should stabilize. To see them again, right-click a screen size in the side panel and click "Show".'
+      )
     }
   }
 
@@ -84,23 +155,114 @@ function perfHandler(event: Event, message?: string) {
 </script>
 
 <style lang="scss" scoped>
+// Colors
+$okay-color: #4aa564;
+$warning-color: #f9c642;
+$alert-color: #cd2026;
+
+// Sizes
+$needle-cover-size: 3.5rem;
+
 .perf-stack-container {
-    @apply flex flex-col-reverse gap-1
+  position: relative;
+  border: 1px solid black;
+  // padding: 0.4rem 1rem;
+  height: 1.5rem;
+  width: 2.5rem;
+  // border-top-left-radius: 3rem;
+  // border-top-right-radius: 3rem;
+  border-radius: 3rem;
+  overflow: hidden;
+
+  &.bg-green {
+    background: rgba($okay-color, 15%);
+    border-color: $okay-color;
+
+    .perf-tick {
+      background: $okay-color;
+    }
+  }
+  &.bg-yellow {
+    background: rgba($warning-color, 15%);
+    border-color: $warning-color;
+
+    .perf-tick {
+      background: $warning-color;
+    }
+  }
+  &.bg-red {
+    background: rgba($alert-color, 15%);
+    border-color: $alert-color;
+
+    .perf-tick {
+      background: $alert-color;
+    }
+  }
+
+  .perf-ticks {
+    @apply flex gap-2 justify-center items-center h-full w-full relative;
+
+    .perf-tick {
+      height: 0.5rem;
+      width: 0.1rem;
+      content: '';
+      // @apply bg-white/30;
+      display: inline-block;
+
+      &:nth-child(1) {
+        transform: rotate(-45deg);
+      }
+
+      &:nth-child(2) {
+        margin-top: -0.2rem;
+      }
+
+      &:nth-child(3) {
+        transform: rotate(45deg);
+      }
+    }
+  }
+
+  .needle {
+    position: absolute;
+    left: 50%;
+    bottom: -0.125rem;
+    height: 1.2rem;
+    width: 0.2rem;
+    content: '';
+    background: #3d3d3d;
+    border-top-left-radius: 100%;
+    border-top-right-radius: 100%;
+    transform-origin: center bottom;
+    transition: all 3s ease-in;
+    // animation: speed 5s infinite;
+  }
+
+  // .needle-cover {
+  //   position: absolute;
+  //   left: calc(50% - (#{$needle-cover-size}/ 2));
+  //   // left: 50%;
+  //   bottom: calc(-#{$needle-cover-size} * 0.9);
+  //   height: $needle-cover-size;
+  //   width: $needle-cover-size;
+  //   content: '';
+  //   background: rgba(black, 100%);
+  //   border-radius: 100%;
+  // }
 }
 
-.perf-stack {
-    @apply h-1 w-4 bg-black rounded-sm; 
-
-    &:nth-child(3) {
-        @apply bg-gray-500;
-    }
-   
-    &:nth-child(2) {
-        @apply bg-gray-400;
-    }
-    
-    &:nth-child(1) {
-        @apply bg-gray-300;
-    }
+@keyframes speed {
+  0% {
+    transform: rotate(0);
+  }
+  40% {
+    transform: rotate(45deg);
+  }
+  55% {
+    transform: rotate(60deg);
+  }
+  75% {
+    transform: rotate(-45deg);
+  }
 }
 </style>

--- a/app/components/PerfMonitor.vue
+++ b/app/components/PerfMonitor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex px-4 gap-2">
+  <div class="flex mx-4 px-1 py-1 gap-1 rounded-[2rem] border border-gray-300">
     <div
       :title="`CPU usage: ${cpu}%`"
       class="perf-stack-container"
@@ -109,9 +109,9 @@ function percentageToDegrees(percentage: number): number {
  * Helper to disable WebViews when system performance may be affected
  */
 function perfHandler(event: Event, message?: string) {
-  if (userAcceptedPerfWarnings === null) {
-    userAlertedAboutPerfWarnings = true
+  userAlertedAboutPerfWarnings = true
 
+  if (userAcceptedPerfWarnings === null) {
     // Immediately hide all webviews
     hideWebViews()
 
@@ -157,11 +157,27 @@ function perfHandler(event: Event, message?: string) {
 <style lang="scss" scoped>
 // Colors
 $okay-color: #4aa564;
+$okay-color--light: #E9F7ED;
 $warning-color: #f9c642;
+$warning-color--light: #fef7e3;
 $alert-color: #cd2026;
+$alert-color--light: #f8dede;
 
 // Sizes
-$needle-cover-size: 3.5rem;
+$needle-cover-size: 0.65rem;
+
+@mixin perf-stack-colors($border-color, $bg-color, $tick-color) {
+  background: $bg-color;
+  border-color: $border-color;
+
+  .needle-cover {
+    border-color: $bg-color;
+  }
+
+  .perf-tick {
+    background: $tick-color;
+  }
+}
 
 .perf-stack-container {
   position: relative;
@@ -175,28 +191,17 @@ $needle-cover-size: 3.5rem;
   overflow: hidden;
 
   &.bg-green {
-    background: rgba($okay-color, 15%);
-    border-color: $okay-color;
-
-    .perf-tick {
-      background: $okay-color;
-    }
+    @include perf-stack-colors($okay-color, $okay-color--light, $okay-color);
   }
   &.bg-yellow {
-    background: rgba($warning-color, 15%);
-    border-color: $warning-color;
-
-    .perf-tick {
-      background: $warning-color;
-    }
+    @include perf-stack-colors(
+      $warning-color,
+      $warning-color--light,
+      $warning-color
+    );
   }
   &.bg-red {
-    background: rgba($alert-color, 15%);
-    border-color: $alert-color;
-
-    .perf-tick {
-      background: $alert-color;
-    }
+    @include perf-stack-colors($alert-color, $alert-color--light, $alert-color);
   }
 
   .perf-ticks {
@@ -208,6 +213,7 @@ $needle-cover-size: 3.5rem;
       content: '';
       // @apply bg-white/30;
       display: inline-block;
+      border-radius: 0.2rem;
 
       &:nth-child(1) {
         transform: rotate(-45deg);
@@ -223,32 +229,35 @@ $needle-cover-size: 3.5rem;
     }
   }
 
+  $needle-width-base: 0.45rem;
+  $needle-height: 1.1rem;
+  $needle-width-tip: 0;
+  $needle-color: #393939;
+
   .needle {
     position: absolute;
-    left: 50%;
-    bottom: -0.125rem;
-    height: 1.2rem;
-    width: 0.2rem;
-    content: '';
-    background: #3d3d3d;
-    border-top-left-radius: 100%;
-    border-top-right-radius: 100%;
+    bottom: 0;
+    left: calc(50% - (#{$needle-width-base} / 2));
+    width: 0;
+    height: 0;
+    border-left: $needle-width-base / 2 solid transparent; // half the base width
+    border-right: $needle-width_base / 2 solid transparent; // half the base width
+    border-bottom: $needle-height solid $needle-color; // height of the triangle
     transform-origin: center bottom;
-    transition: all 3s ease-in;
-    // animation: speed 5s infinite;
   }
 
-  // .needle-cover {
-  //   position: absolute;
-  //   left: calc(50% - (#{$needle-cover-size}/ 2));
-  //   // left: 50%;
-  //   bottom: calc(-#{$needle-cover-size} * 0.9);
-  //   height: $needle-cover-size;
-  //   width: $needle-cover-size;
-  //   content: '';
-  //   background: rgba(black, 100%);
-  //   border-radius: 100%;
-  // }
+  .needle-cover {
+    z-index: 1;
+    position: absolute;
+    left: calc(50% - (#{$needle-cover-size}/ 2));
+    bottom: calc(-#{$needle-cover-size} * 0.5);
+    height: $needle-cover-size;
+    width: $needle-cover-size;
+    content: '';
+    background: rgba(#3d3d3d, 100%);
+    border-radius: 100%;
+    border: 1px solid white;
+  }
 }
 
 @keyframes speed {

--- a/app/components/PerfMonitor.vue
+++ b/app/components/PerfMonitor.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="flex px-4 gap-2">
+    <div :title="`CPU usage: ${cpu}%`" class="perf-stack-container">
+      <div v-if="cpu > 20" class="perf-stack"></div>
+      <div v-if="cpu >= 50" class="perf-stack"></div>
+      <div v-if="cpu >= 80" class="perf-stack"></div>
+    </div>
+    <div :title="`Memory usage: ${memory}%`" class="perf-stack-container">
+      <div v-if="cpu > 20" class="perf-stack"></div>
+      <div v-else-if="cpu >= 50" class="perf-stack"></div>
+      <div v-else-if="cpu >= 80" class="perf-stack"></div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ipcRenderer } from 'electron'
+import isElectron from 'is-electron'
+import { useArtboardsStore } from '@/store/artboards'
+
+const artboards = useArtboardsStore()
+
+const cpu = ref(0)
+const memory = ref(0)
+
+onMounted(() => {
+  if (isElectron()) {
+    ipcRenderer.on('perf-warning', perfHandler)
+
+    ipcRenderer.on('perf-cpu', (e, value) => perfStreamHandler('cpu', value))
+
+    ipcRenderer.on('perf-memory', (e, value) =>
+      perfStreamHandler('memory', value)
+    )
+  }
+})
+
+let userAcceptedPerfWarnings: boolean | null = null
+
+function perfStreamHandler(type: 'cpu' | 'memory', value: number) {
+  if (type === 'cpu') {
+    cpu.value = value
+  } else if (type === 'memory') {
+    memory.value = value
+  }
+}
+
+/**
+ * Helper to disable WebViews when system performance may be affected
+ */
+function perfHandler(event: Event, message?: string) {
+  if (userAcceptedPerfWarnings === null) {
+    // Immediately hide all webviews
+    hideWebViews()
+
+    if (confirm(`Performance warning! ${message} Continue anyway?`)) {
+      userAcceptedPerfWarnings = true
+      showWebViews()
+    } else {
+      userAcceptedPerfWarnings = false
+
+      // 1. Hide all Artboards, so user can re-enable
+      artboards.list.map((artboard) => {
+        artboard.isVisible = false
+      })
+
+      // 2. Re-enable WebViews
+      showWebViews()
+    }
+  }
+
+  function hideWebViews() {
+    document.querySelectorAll('webview').forEach((webview) => {
+      webview.style.visibility = 'hidden'
+    })
+  }
+
+  function showWebViews() {
+    document.querySelectorAll('webview').forEach((webview) => {
+      webview.style.visibility = 'visible'
+    })
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.perf-stack-container {
+    @apply flex flex-col-reverse gap-1
+}
+
+.perf-stack {
+    @apply h-1 w-4 bg-black rounded-sm; 
+
+    &:nth-child(3) {
+        @apply bg-gray-500;
+    }
+   
+    &:nth-child(2) {
+        @apply bg-gray-400;
+    }
+    
+    &:nth-child(1) {
+        @apply bg-gray-300;
+    }
+}
+</style>

--- a/app/components/ToolBar/index.vue
+++ b/app/components/ToolBar/index.vue
@@ -55,7 +55,9 @@
     <!-- <UpdateChannel /> -->
     <div class="draggable" @dblclick="toggleWindowMaximize" />
     <div class="flex justify-end">
-      <PerfMonitor />
+      <!-- <template v-if="isDev"> -->
+        <PerfMonitor />
+      <!-- </template> -->
       <InstallUpdateButton />
     </div>
   </div>
@@ -70,6 +72,9 @@ import InstallUpdateButton from '@/components/ToolBar/InstallUpdateButton.vue'
 
 import UpdateChannel from '@/components/Settings/UpdateChannel.vue'
 import Artboard from '@/components/Screens/Artboard.vue'
+
+const runtimeConfig = useRuntimeConfig()
+const isDev = runtimeConfig.public.DEV
 
 // Pinia
 import { useArtboardsStore } from '~/store/artboards'

--- a/app/components/ToolBar/index.vue
+++ b/app/components/ToolBar/index.vue
@@ -53,10 +53,11 @@
       <SwitchMode />
     </div> -->
     <!-- <UpdateChannel /> -->
+    <div class="draggable" @dblclick="toggleWindowMaximize" />
     <div class="flex justify-end">
+      <PerfMonitor />
       <InstallUpdateButton />
     </div>
-    <div class="draggable" @dblclick="toggleWindowMaximize" />
   </div>
 </template>
 
@@ -77,6 +78,7 @@ import { useGuiStore } from '~/store/gui'
 
 // TODO: Re-connect with Electron
 import * as remote from '@electron/remote'
+import PerfMonitor from '../PerfMonitor.vue'
 
 const artboards = useArtboardsStore()
 const history = useHistoryStore()

--- a/app/components/panzoom/Panzoom.vue
+++ b/app/components/panzoom/Panzoom.vue
@@ -2,21 +2,32 @@
   <div style="display: inline-block; width: 100%; height: 100%">
     <!-- We 'panzoom-exclude' to mark this as not relevant to Panzoom -->
     <!-- <PanzoomControls v-if="panzoomInstance" :instance="panzoomInstance" /> -->
-    <div id="canvas" ref="outerPanArea" class="panzoom-container" :class="{
-      'dev-visual-debugger': showCanvasDebugger,
-    }">
+    <div
+      id="canvas"
+      ref="outerPanArea"
+      class="panzoom-container"
+      :class="{
+        'dev-visual-debugger': showCanvasDebugger,
+      }"
+    >
       <!-- For transform-origin: 50% 50% to work, this next element HAS to be display:block -->
-      <div ref="innerPanArea" style="
-                display: block;
-                position: relative;
-                height: 100%;
-                width: 100%;
-                overflow: visible;
-              ">
+      <div
+        ref="innerPanArea"
+        style="
+          display: block;
+          position: relative;
+          height: 100%;
+          width: 100%;
+          overflow: visible;
+        "
+      >
         <!-- Now we have the real panzoom content inside: -->
-        <div class="panzoom-inner" :class="{
-          'dev-visual-debugger': showCanvasDebugger,
-        }">
+        <div
+          class="panzoom-inner"
+          :class="{
+            'dev-visual-debugger': showCanvasDebugger,
+          }"
+        >
           <slot />
         </div>
       </div>
@@ -43,6 +54,7 @@ import { useInteractionStore } from '~/store/interactions'
 import useEventHandler from '../Screens/useEventHandler'
 import { useDevStore } from '~/store/dev'
 import { initialPanZoom } from './panzoomFns'
+
 
 // Connect w/ Electron
 
@@ -104,6 +116,7 @@ onMounted(async () => {
   // Init Panzoom globally
   // We use the 'canvas' option to enable interactions on the parent DOM Node as well
   // Docs: https://github.com/timmywil/panzoom#canvas
+
   $root.$panzoom = Panzoom(innerPanArea.value, {
     canvas: true, // Allows parent to control child
     cursor: 'grab',
@@ -215,6 +228,8 @@ function enableEventListeners() {
     })
   }
 }
+
+
 
 /**
  * Handles wheel events (i.e. mousewheel)
@@ -341,7 +356,6 @@ function fitToScreen() {
 }
 
 .dev-visual-debugger {
-
   &:before,
   &:after {
     position: absolute;
@@ -367,7 +381,6 @@ function fitToScreen() {
 
   // Nested debugger
   .dev-visual-debugger {
-
     // Vertical line
     &:before {
       position: absolute;

--- a/app/components/panzoom/Panzoom.vue
+++ b/app/components/panzoom/Panzoom.vue
@@ -338,6 +338,7 @@ function fitToScreen() {
   position: relative; // Important
   display: inline-block;
   overflow: visible;
+  will-change: auto;
 }
 
 #parent {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -9,6 +9,8 @@ import mainWindowInit from './mainWindow'
 import { getPackageJson } from './util'
 import { RuntimeConfig } from './config'
 import startPerfMonitoring from './usage-monitoring'
+import { installBrowsers } from './cross-browser/playwright-browser-manager'
+import enableCrossBrowserScreenshots from './cross-browser/screenshots/api'
 ;(async () => {
   const version = await getPackageJson().then((data) => data.version)
 
@@ -77,4 +79,10 @@ import startPerfMonitoring from './usage-monitoring'
 
   // Start monitoring CPU/Memory usage
   startPerfMonitoring()
+
+  // Check for browser installations
+  installBrowsers().then(() => {
+    // Screenshot worker
+    enableCrossBrowserScreenshots()
+  })
 })()

--- a/app/electron/mainWindow.ts
+++ b/app/electron/mainWindow.ts
@@ -22,7 +22,7 @@ import { RuntimeConfig } from './config'
 const INDEX_PATH = path.join(__dirname, '..', 'renderer', 'index.html')
 const DEV_SERVER_URL = process.env.DEV_SERVER_URL // eslint-disable-line prefer-destructuring
 
-export default function init() {
+export default async function init(): Promise<BrowserWindow> {
   // Get saved window position state
   windowPosition.onAppLoad()
   const initialWindowPos = windowPosition.getState()
@@ -43,7 +43,7 @@ export default function init() {
     titleBarStyle: 'hiddenInset', // Hide the bar
   })
 
-  winHandler.onCreated(async (browserWindow: BrowserWindow) => {
+  return await winHandler.onCreated(async (browserWindow: BrowserWindow) => {
     // Initialize the runtime config
     // Exposes file paths and other dynamic properties
     const appConfig = RuntimeConfig.getInstance()
@@ -100,5 +100,8 @@ export default function init() {
     browserWindow.on('closed', () => {
       browserWindow = null
     })
+
+    // Return the window instance
+    return browserWindow
   })
 }

--- a/app/electron/mainWindow.ts
+++ b/app/electron/mainWindow.ts
@@ -11,12 +11,9 @@ import windowPosition from './windowPosition'
 // import browserInstaller from './browser-installer'
 import { setMenu } from './menu'
 import { init as initUpdates } from './updates'
-import browserInstaller from './browser-installer'
-import { installBrowsers } from './cross-browser/playwright-browser-manager'
 
 import log from 'electron-log'
 import isDev from 'electron-is-dev'
-import enableCrossBrowserScreenshots from './cross-browser/screenshots/api'
 import { RuntimeConfig } from './config'
 
 const INDEX_PATH = path.join(__dirname, '..', 'renderer', 'index.html')
@@ -77,11 +74,7 @@ export default async function init(): Promise<BrowserWindow> {
       initUpdates(browserWindow)
     })
 
-    // Check for browser installations
-    await installBrowsers()
-
-    // Screenshot worker test
-    enableCrossBrowserScreenshots()
+    
 
     // Reload when requested by the renderer process
     ipcMain.handle('reload-window', () => {

--- a/app/electron/usage-monitoring.ts
+++ b/app/electron/usage-monitoring.ts
@@ -5,7 +5,7 @@ import { RuntimeConfig } from './config'
 let cpuInterval: string | number | NodeJS.Timeout | undefined
 let memoryInterval: string | number | NodeJS.Timeout | undefined
 
-const cpuThreshold = 80 // 80% CPU usage threshold
+const cpuThreshold = 85 // 85% CPU usage threshold
 const memoryThreshold = 90 // 90% memory usage threshold
 
 let currentWindow: BrowserWindow | null = null
@@ -39,7 +39,7 @@ function monitorCPUUsage() {
       const cpuData = await si.currentLoad()
       const cpuUsagePercent = cpuData.currentLoad
 
-      emitToRenderer('perf-cpu', Math.round(cpuUsagePercent))
+      emitToRenderer('perf-cpu', Math.round(cpuUsagePercent)) // Send CPU usage to renderer process
 
       if (cpuUsagePercent >= cpuThreshold) {
         const warningMessage = `High memory usage: ${cpuUsagePercent.toFixed(
@@ -47,9 +47,11 @@ function monitorCPUUsage() {
         )}%`
         console.warn(warningMessage)
         emitToRenderer('perf-warning', warningMessage)
+      } else {
+        console.info('CPU usage:', cpuUsagePercent.toFixed(2), '%')
       }
     } catch (err) {
-      console.error('Error retrieving CPU usage:', err)
+      console.debug('Error retrieving CPU usage:', err)
     }
   }, 1000)
 }
@@ -62,7 +64,7 @@ function monitorMemoryUsage() {
       const usedMemory = memData.active
       const memoryUsagePercent = (usedMemory / totalMemory) * 100
 
-      emitToRenderer('perf-memory', Math.round(memoryUsagePercent))
+      emitToRenderer('perf-memory', Math.round(memoryUsagePercent)) // Send memory usage to renderer process
 
       if (memoryUsagePercent >= memoryThreshold) {
         const warningMessage = `High memory usage: ${memoryUsagePercent.toFixed(
@@ -71,7 +73,7 @@ function monitorMemoryUsage() {
         console.warn(warningMessage)
         emitToRenderer('perf-warning', warningMessage)
       } else {
-        console.log('Memory usage:', memoryUsagePercent.toFixed(2), '%')
+        console.info('Memory usage:', memoryUsagePercent.toFixed(2), '%')
       }
     } catch (err) {
       console.error('Error retrieving memory usage:', err)

--- a/app/electron/usage-monitoring.ts
+++ b/app/electron/usage-monitoring.ts
@@ -1,0 +1,80 @@
+import si from 'systeminformation'
+import { app, BrowserWindow } from 'electron'
+import { RuntimeConfig } from './config'
+
+let cpuInterval: string | number | NodeJS.Timeout | undefined
+let memoryInterval: string | number | NodeJS.Timeout | undefined
+
+const cpuThreshold = 80 // 80% CPU usage threshold
+const memoryThreshold = 90 // 90% memory usage threshold
+
+let currentWindow: BrowserWindow | null = null
+
+const emitToRenderer = (channel: string, ...args: any[]) => {
+  if (currentWindow) {
+    currentWindow.webContents.send(channel, ...args)
+  } else {
+    throw new Error('No focused window found')
+  }
+}
+
+export default function startMonitoring() {
+  const appConfig = RuntimeConfig.getInstance()
+  currentWindow = appConfig.window
+
+  monitorCPUUsage()
+  monitorMemoryUsage()
+
+  // Register before-quit event listener
+  app.on('before-quit', () => {
+    // Clear the monitoring intervals
+    clearInterval(cpuInterval)
+    clearInterval(memoryInterval)
+  })
+}
+
+function monitorCPUUsage() {
+  cpuInterval = setInterval(async () => {
+    try {
+      const cpuData = await si.currentLoad()
+      const cpuUsagePercent = cpuData.currentLoad
+
+      emitToRenderer('perf-cpu', Math.round(cpuUsagePercent))
+
+      if (cpuUsagePercent >= cpuThreshold) {
+        const warningMessage = `High memory usage: ${cpuUsagePercent.toFixed(
+          2
+        )}%`
+        console.warn(warningMessage)
+        emitToRenderer('perf-warning', warningMessage)
+      }
+    } catch (err) {
+      console.error('Error retrieving CPU usage:', err)
+    }
+  }, 1000)
+}
+
+function monitorMemoryUsage() {
+  memoryInterval = setInterval(async () => {
+    try {
+      const memData = await si.mem()
+      const totalMemory = memData.total
+      const usedMemory = memData.active
+      const memoryUsagePercent = (usedMemory / totalMemory) * 100
+
+      emitToRenderer('perf-memory', Math.round(memoryUsagePercent))
+
+      if (memoryUsagePercent >= memoryThreshold) {
+        const warningMessage = `High memory usage: ${memoryUsagePercent.toFixed(
+          2
+        )}%`
+        console.warn(warningMessage)
+        emitToRenderer('perf-warning', warningMessage)
+      } else {
+        console.log('Memory usage:', memoryUsagePercent.toFixed(2), '%')
+      }
+    } catch (err) {
+      console.error('Error retrieving memory usage:', err)
+    }
+  }, 1000)
+}

--- a/app/mixins/rightClickMenu.ts
+++ b/app/mixins/rightClickMenu.ts
@@ -46,7 +46,7 @@ export default function (artboard: Artboard) {
       label: artboard.isVisible ? 'Hide' : 'Show',
       click() {
         const store = useArtboardsStore()
-        store.changeArtboardVisibility(artboard)
+        store.changeArtboardVisibility(artboard.id)
       },
     })
   )

--- a/app/package.json
+++ b/app/package.json
@@ -40,6 +40,7 @@
     "electron-store": "^8.1.0",
     "electron-updater": "5.3.0",
     "html-to-image": "^1.11.11",
+    "systeminformation": "^5.18.3",
     "uuid": "8.3.2",
     "vue": "^3.2.47",
     "vuetify": "^3.0.6"

--- a/app/store/artboards.ts
+++ b/app/store/artboards.ts
@@ -87,12 +87,15 @@ export const useArtboardsStore = defineStore('artboards', {
         ? (artboard.isInViewport = isVisible)
         : console.warn('No artboard found')
     },
-    changeArtboardVisibility(artboard: Artboard) {
-      // 1. Get the artboard.id
-      const id = artboard.id
-      const index = this.list.findIndex((obj) => obj.id === id)
-      // 2. Change the visibility of just that artboard's is property
-      this.list[index].isVisible = !artboard.isVisible
+    changeArtboardVisibility(id: Artboard['id']) {
+      const match = this.list.find((obj) => obj.id === id)
+
+      if (!match) {
+        console.error('Artboard not found')
+        return
+      }
+
+      match.isVisible = !match.isVisible
     },
     updateArtboardAtIndex(artboard: Partial<Artboard>) {
       // 1. Get the artboard.id

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,6 +2841,7 @@ __metadata:
     sass: 1.60.0
     sortablejs: ^1.15.0
     sortablejs-vue3: ^1.2.9
+    systeminformation: ^5.18.3
     tailwindcss: ^3.3.2
     typescript: ^5.0.0
     uuid: 8.3.2
@@ -20300,6 +20301,16 @@ __metadata:
   version: 2.0.17
   resolution: "synchronous-promise@npm:2.0.17"
   checksum: 1babe643d8417789ef6e5a2f3d4b8abcda2de236acd09bbe2c98f6be82c0a2c92ed21a6e4f934845fa8de18b1435a9cba1e8c3d945032e8a532f076224c024b1
+  languageName: node
+  linkType: hard
+
+"systeminformation@npm:^5.18.3":
+  version: 5.18.3
+  resolution: "systeminformation@npm:5.18.3"
+  bin:
+    systeminformation: lib/cli.js
+  checksum: dac4d0b92c102d4f5766692ea275c54bf234012a989e3383e43511ada7193957843e5ad391df3dfea89d3579ae0d9f9e7ca1e555b48f30c173374dcb8f645ce3
+  conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds some simple monitoring UI for end-users + alert when >80% memory/CPU. NOTE: Currently this is only behind the `isDev` flag, so it will not be in the built app; only in dev mode.

This should make it easier to identify why Reflex starts to feel laggy, so you can see that when you have 5 screen sizes displayed all at full-height, you'll be able to see how your system's usage also increases into the yellow/red. Sometimes you may _want_ to keep using it, even if laggy, so that you can see some specific thing across many screen sizes, so we won't prevent you from doing it, but we will offer a lifeboat if you want to turn back.