### PR TITLE
Full width/height mode

### DIFF
--- a/app/assets/icons/arrows-pointing-in.svg
+++ b/app/assets/icons/arrows-pointing-in.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 9L9 4.5M9 9L4.5 9M9 9L3.75 3.75M9 15L9 19.5M9 15L4.5 15M9 15L3.75 20.25M15 9H19.5M15 9V4.5M15 9L20.25 3.75M15 15H19.5M15 15L15 19.5M15 15L20.25 20.25" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/assets/icons/arrows-pointing-out.svg
+++ b/app/assets/icons/arrows-pointing-out.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.75 3.75V8.25M3.75 3.75H8.25M3.75 3.75L9 9M3.75 20.25V15.75M3.75 20.25H8.25M3.75 20.25L9 15M20.25 3.75L15.75 3.75M20.25 3.75V8.25M20.25 3.75L15 9M20.25 20.25H15.75M20.25 20.25V15.75M20.25 20.25L15 15" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/components/Fullscreen.vue
+++ b/app/components/Fullscreen.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="h-full w-full">
+    <Artboard id="123" :height="height" :width="width" :hide-chrome="true" :webcontext-active-override="true" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import Artboard from './Screens/Artboard.vue';
+
+// The height and width should be 100% viewport even when resized
+const height = ref(0) // TODO: Need to subtract the height of the header
+const width = ref(0)
+
+// Get the height and width of the viewport
+onMounted(() => {
+  height.value = window.innerHeight
+  width.value = window.innerWidth
+})
+
+// Resize the viewport when the window is resized
+onMounted(() => {
+  window.addEventListener('resize', () => {
+    height.value = window.innerHeight
+    width.value = window.innerWidth
+  })
+})
+</script>
+
+<style scoped></style>

--- a/app/components/Screens/WebPage.vue
+++ b/app/components/Screens/WebPage.vue
@@ -2,6 +2,7 @@
   <webview
     ref="frame"
     class="frame"
+    :style="{ pointerEvents: allowInteractions ? 'auto' : 'none' }"
     v-bind="webviewOptions"
     :electronConfig="webpreferences"
   />
@@ -495,6 +496,5 @@ webview {
   height: 100%;
   width: 100%;
   position: relative;
-  pointer-events: none; // Prevent interactions/events by default
 }
 </style>

--- a/app/components/ToolBar/index.vue
+++ b/app/components/ToolBar/index.vue
@@ -21,6 +21,14 @@
         @click="toggleSiteTree()"
         data-testid="toggle-site-tree"
       />
+      <Button
+        role="ghost"
+        :icon="data.isFullscreenArtboard ? 'arrows-pointing-in' : 'arrows-pointing-out'"
+        :is-pressed="data.isFullscreenArtboard"
+        :tight="false"
+        :title="data.isFullscreenArtboard ? 'Exit Fullscreen' : 'Fullscreen'"
+        @click="toggleFSArtboard()"
+      />
     </div>
     <div class="draggable" @dblclick="toggleWindowMaximize" />
     <div v-if="data.artboards.length" id="toolbar__url-container">
@@ -96,6 +104,7 @@ const data = reactive({
   favicon: computed(() => history.currentPage.favicon),
   sidebar: computed(() => gui.sidebar),
   siteTreeEnabled: computed(() => gui.siteTree),
+  isFullscreenArtboard: computed(() => gui.isFullscreenArtboard),
 })
 
 const state = reactive({
@@ -170,6 +179,10 @@ function toggleFullscreen() {
   // See: https://electronjs.org/docs/api/remote#passing-callbacks-to-the-main-process
   // const window = remote.getCurrentWindow()
   // state.isFullScreen = !!window.isFullScreen()
+}
+
+function toggleFSArtboard() {  
+  gui.toggleGui('isFullscreenArtboard')
 }
 </script>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,9 +4,14 @@
     <SidePanel />
     <SiteTree />
     <Screenshots />
-    <Panzoom>
-      <Artboards />
-    </Panzoom>
+    <template v-if="!isFullscreenArtboard">
+      <Panzoom>
+        <Artboards />
+      </Panzoom>
+    </template>
+    <template v-if="isFullscreenArtboard">
+      <Fullscreen />
+    </template>
   </div>
 </template>
 
@@ -19,8 +24,13 @@ import Artboards from '@/components/Screens/Artboards.vue'
 import useEventHandler from '@/components/Screens/useEventHandler'
 import DevModeHud from '~/components/DevModeHud.vue'
 import SiteTree from '@/components/SiteTree/index.vue'
+import Fullscreen from '@/components/Fullscreen.vue'
+import { useGuiStore } from "@/store/gui"
 
 const { init } = useEventHandler() // init event handling
+const gui = useGuiStore()
+
+const isFullscreenArtboard = computed(() => gui.isFullscreenArtboard)
 
 onMounted(() => {
   init() // initialize

--- a/app/store/gui.ts
+++ b/app/store/gui.ts
@@ -6,6 +6,7 @@ interface State {
   discoMode: boolean
   siteTree: boolean
   isScreensFullHeight: boolean
+  isFullscreenArtboard: boolean
 }
 
 export const useGuiStore = defineStore('gui', {
@@ -15,6 +16,7 @@ export const useGuiStore = defineStore('gui', {
     discoMode: false,
     siteTree: false,
     isScreensFullHeight: false,
+    isFullscreenArtboard: false,
   }),
   getters: {},
   actions: {
@@ -28,6 +30,7 @@ export const useGuiStore = defineStore('gui', {
     setGui(key: keyof State, value: boolean) {
       this[key] = value
     },
+
   },
   // Save this store in localStorage
   persist: true,


### PR DESCRIPTION
- [ ] Toggles a full-width/height view of the current website
- [ ] Easily switch to another screen size

Tests
- [ ] Icon in toolbar does not overlap
- [ ] Able to capture screenshot
- [ ] Size of artboard is updated when the app window is resized
- [ ] User can still navigate to other pages using the URL input